### PR TITLE
feat(git-bulk-clean): maintain all ghq repos hourly

### DIFF
--- a/hosts/M4-Max/default.nix
+++ b/hosts/M4-Max/default.nix
@@ -70,11 +70,17 @@ nix-darwin.lib.darwinSystem {
         inputs.agent-skills.homeManagerModules.default
         inputs.git-bulk-clean.homeManagerModules.default
         {
-          # Keep the git-bulk-clean clone lean via a background launchd agent.
+          # Maintain every ghq-managed repository via a background launchd agent.
           services.git-maintenance = {
             enable = true;
-            repositories = [ "/Users/${username}/ghq/github.com/takeokunn/git-bulk-clean.git" ];
+            ghq.enable = true;
+            interval = 3600; # 1 hour
           };
+
+          # launchd agents don't inherit home.sessionVariables (shell-only), so
+          # SSH-remote repos fail fetch without the agent socket set explicitly.
+          launchd.agents.git-maintenance.config.EnvironmentVariables.SSH_AUTH_SOCK =
+            "/Users/${username}/.gnupg/S.gpg-agent.ssh";
         }
       ];
       home-manager.extraSpecialArgs = {


### PR DESCRIPTION
## Summary
- Switch `services.git-maintenance` on M4-Max from a single hardcoded repo to `ghq.enable = true`, sweeping every ghq-managed repository.
- Drop the maintenance interval from the module default to 1 hour.
- Set `SSH_AUTH_SOCK` on the launchd agent explicitly — it doesn't inherit `home.sessionVariables` (shell-only), which was breaking fetches on SSH-remote repos.

## Test plan
- [x] `nix flake check` — exit 0
- [x] `sudo nix run nix-darwin -- switch --flake .#M4-Max` — activated cleanly, twice
- [x] Live verification via `~/Library/Logs/git-maintenance.log`: ghq-wide sweep confirmed working (72/79 ok before the SSH fix, 74/79 ok after)
- [ ] Known, deferred limitation: 5 HTTPS-remote repos still fail under launchd due to a non-interactive credential-helper gap (`osxkeychain`/`gh auth git-credential`), unrelated to this change's own code — tracked as a follow-up decision, not blocking this PR