### PR TITLE
feat(fish): fetch fresh main before cutting worktrees, add worktree_switch

### DIFF
--- a/home-manager/shell/fish/functions/__fzf_ghq_new_worktree.fish
+++ b/home-manager/shell/fish/functions/__fzf_ghq_new_worktree.fish
@@ -82,6 +82,19 @@ function __fzf_ghq_new_worktree
     # which the repository's own HEAD symref points at. The first two candidates
     # only become available once something has written the refspec and fetched.
     if test -z "$base_ref"
+        # An explicit refspec on this one call, rather than a persisted
+        # remote.origin.fetch config, keeps a `ghq get --bare` clone from
+        # permanently gaining refs/remotes/* it never asked for. A failed
+        # fetch is not fatal here -- the three-step chain below still has
+        # local refs to fall back to.
+        if git -C $repo_path remote get-url origin >/dev/null 2>&1
+            set -l fetch_output (git -C $repo_path fetch origin '+refs/heads/main:refs/remotes/origin/main' 2>&1)
+            if test $status -ne 0
+                echo "fzf_ghq: fetch of origin/main failed ($fetch_output); falling back to local refs" >&2
+            end
+        end
+    end
+    if test -z "$base_ref"
         set base_ref (git -C $repo_path symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | string replace 'refs/remotes/' '')
     end
     if test -z "$base_ref"

--- a/home-manager/shell/fish/functions/tests/fzf_ghq_fetch.test.fish
+++ b/home-manager/shell/fish/functions/tests/fzf_ghq_fetch.test.fish
@@ -1,0 +1,176 @@
+#!/usr/bin/env fish
+# Standalone test script for __fzf_ghq_new_worktree's guarded-fetch step
+# (base_ref resolution, lines 84-96 of __fzf_ghq_new_worktree.fish). Run
+# with: fish path/to/fzf_ghq_fetch.test.fish
+# Never touches the real $HOME or this repo's own .state/: every test runs
+# against a scratch $HOME and scratch bare+clone git repos under mktemp.
+
+set -l script_dir (status dirname)
+source $script_dir/../__fzf_ghq_new_worktree.fish
+
+set -g TESTS_PASSED 0
+set -g TESTS_FAILED 0
+
+function pass -a description
+    echo "PASS: $description"
+    set -g TESTS_PASSED (math $TESTS_PASSED + 1)
+end
+
+function fail -a description
+    echo "FAIL: $description"
+    set -g TESTS_FAILED (math $TESTS_FAILED + 1)
+end
+
+# Same scratch shape as fzf_ghq.test.fish's make_scratch_repo, but keeps the
+# clone directory around (instead of leaving it to be discarded) so a test
+# can push a second, later commit through it to simulate the remote moving
+# on after the bare clone was made. Prints "<bare>" then "<clone>" on
+# separate lines, so command substitution captures them as two list
+# elements.
+function make_scratch_repo_pair
+    set -l dir (mktemp -d)
+    set -l bare "$dir/scratch.git"
+    git init --bare -q "$bare"
+    git -C "$bare" symbolic-ref HEAD refs/heads/main
+
+    set -l clone "$dir/clone"
+    git clone -q "$bare" "$clone" >/dev/null 2>&1
+    git -C "$clone" symbolic-ref HEAD refs/heads/main
+    echo seed >"$clone/README.md"
+    git -C "$clone" add README.md
+    git -c user.email=test@example.com -c user.name=test -C "$clone" commit -q -m "initial commit"
+    git -C "$clone" push -q origin HEAD:refs/heads/main
+
+    echo $bare
+    echo $clone
+end
+
+function test_fetch_freshness
+    set -lx HOME (mktemp -d)
+    set -l pair (make_scratch_repo_pair)
+    set -l bare $pair[1]
+    set -l clone $pair[2]
+
+    # A `ghq get --bare` clone carries no origin remote at all, so give the
+    # scratch bare repo one pointing back at the clone (the opposite
+    # direction from a normal clone, but all that matters here is that
+    # `git -C $bare fetch origin ...` has somewhere real to fetch from).
+    git -C "$bare" remote add origin "$clone"
+
+    # Advance the "remote" clone with a second commit AFTER the bare repo
+    # was set up, simulating time passing after `ghq get --bare` ran.
+    echo second >"$clone/second.txt"
+    git -C "$clone" add second.txt
+    git -c user.email=test@example.com -c user.name=test -C "$clone" commit -q -m "second commit"
+    set -l new_sha (git -C "$clone" rev-parse HEAD)
+
+    set -l result (__fzf_ghq_new_worktree $bare)
+    set -l exit_code $status
+
+    if test $exit_code -eq 0
+        pass "freshness: __fzf_ghq_new_worktree exits 0"
+    else
+        fail "freshness: __fzf_ghq_new_worktree exit code (expected 0, got $exit_code)"
+    end
+
+    set -l worktree_path $result[-1]
+    set -l worktree_head (git -C "$worktree_path" rev-parse HEAD 2>/dev/null)
+
+    if test "$worktree_head" = "$new_sha"
+        pass "freshness: worktree HEAD is the freshly-fetched commit, not the stale bare-clone-time commit"
+    else
+        fail "freshness: worktree HEAD (expected '$new_sha', got '$worktree_head')"
+    end
+end
+
+function test_fetch_failure_fallback
+    set -lx HOME (mktemp -d)
+    set -l pair (make_scratch_repo_pair)
+    set -l bare $pair[1]
+
+    # Point origin at a path that does not exist so the fetch fails outright.
+    set -l nonexistent (mktemp -u)
+    git -C "$bare" remote add origin "$nonexistent"
+
+    set -l expected_sha (git -C "$bare" rev-parse HEAD)
+
+    set -l result (__fzf_ghq_new_worktree $bare 2>"$TMPDIR/fetch_failure_stderr.$fish_pid")
+    set -l exit_code $status
+    set -l stderr_output (cat "$TMPDIR/fetch_failure_stderr.$fish_pid")
+    rm -f "$TMPDIR/fetch_failure_stderr.$fish_pid"
+
+    if test $exit_code -eq 0
+        pass "fetch-failure: __fzf_ghq_new_worktree still exits 0 via local-ref fallback"
+    else
+        fail "fetch-failure: __fzf_ghq_new_worktree exit code (expected 0, got $exit_code)"
+    end
+
+    set -l worktree_path $result[-1]
+    set -l worktree_head (git -C "$worktree_path" rev-parse HEAD 2>/dev/null)
+
+    if test -n "$worktree_path"; and test -d "$worktree_path"; and test "$worktree_head" = "$expected_sha"
+        pass "fetch-failure: produces a valid worktree via the local HEAD-symref fallback"
+    else
+        fail "fetch-failure: valid worktree via fallback (path='$worktree_path', head='$worktree_head', expected='$expected_sha')"
+    end
+
+    if string match -q '*falling back to local refs*' -- $stderr_output
+        pass "fetch-failure: 'falling back to local refs' warning printed on stderr"
+    else
+        fail "fetch-failure: expected 'falling back to local refs' warning on stderr, got: $stderr_output"
+    end
+end
+
+function test_no_origin_remote_regression
+    set -lx HOME (mktemp -d)
+    set -l pair (make_scratch_repo_pair)
+    set -l bare $pair[1]
+
+    # No origin remote configured on the bare repo at all -- matches
+    # fzf_ghq.test.fish's make_scratch_repo shape. The fetch guard must not
+    # fire, so behavior must be identical to before this change existed.
+    if git -C "$bare" remote get-url origin >/dev/null 2>&1
+        fail "no-origin: precondition violated -- scratch bare repo unexpectedly has an origin remote"
+        return
+    end
+
+    set -l expected_sha (git -C "$bare" rev-parse HEAD)
+
+    set -l result (__fzf_ghq_new_worktree $bare 2>"$TMPDIR/no_origin_stderr.$fish_pid")
+    set -l exit_code $status
+    set -l stderr_output (cat "$TMPDIR/no_origin_stderr.$fish_pid")
+    rm -f "$TMPDIR/no_origin_stderr.$fish_pid"
+
+    if test $exit_code -eq 0
+        pass "no-origin: __fzf_ghq_new_worktree exits 0"
+    else
+        fail "no-origin: __fzf_ghq_new_worktree exit code (expected 0, got $exit_code)"
+    end
+
+    if string match -q '*fetch*' -- $stderr_output
+        fail "no-origin: no fetch-related stderr expected, got: $stderr_output"
+    else
+        pass "no-origin: no fetch-related stderr printed"
+    end
+
+    set -l worktree_path $result[-1]
+    set -l worktree_head (git -C "$worktree_path" rev-parse HEAD 2>/dev/null)
+
+    if test -n "$worktree_path"; and test -d "$worktree_path"; and test "$worktree_head" = "$expected_sha"
+        pass "no-origin: produces a valid worktree via the HEAD-symref fallback, unchanged from before"
+    else
+        fail "no-origin: valid worktree via fallback (path='$worktree_path', head='$worktree_head', expected='$expected_sha')"
+    end
+end
+
+test_fetch_freshness
+test_fetch_failure_fallback
+test_no_origin_remote_regression
+
+echo ""
+echo "Summary: $TESTS_PASSED passed, $TESTS_FAILED failed"
+
+if test $TESTS_FAILED -gt 0
+    exit 1
+end
+exit 0

--- a/home-manager/shell/fish/functions/worktree_switch.fish
+++ b/home-manager/shell/fish/functions/worktree_switch.fish
@@ -1,0 +1,39 @@
+# Sibling of fzf_ghq: reuses its worktree-enumeration and fzf-picker logic
+# (Stage 2 of fzf_ghq.fish) but scoped to only the repo containing $PWD, with
+# no cross-repo `ghq list` stage and no tmux session handling -- this is a
+# plain `cd`. Unlike worktree_new, this never creates a worktree: with zero
+# worktrees found it reports and returns rather than falling back to create.
+function worktree_switch
+    set -l git_common_dir (git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+    if test -z "$git_common_dir"
+        echo "worktree_switch: not inside a git repository" >&2
+        return 1
+    end
+    set -l repo_path (string replace -r '/\.git$' '' -- $git_common_dir)
+
+    # Exclude the bare repo's own entry by comparing against git's own
+    # canonical path for it, not $repo_path verbatim -- mirrors the same
+    # symlink-resolution caveat documented in fzf_ghq.fish.
+    set -l repo_git_dir (git -C $repo_path rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+    set -l worktree_paths
+    for line in (git -C $repo_path worktree list --porcelain)
+        if string match -q 'worktree *' -- $line
+            set -l wt_path (string replace -r '^worktree ' '' -- $line)
+            if test "$wt_path" != "$repo_git_dir"
+                set -a worktree_paths $wt_path
+            end
+        end
+    end
+
+    if test (count $worktree_paths) -eq 0
+        echo "worktree_switch: no worktrees found for this repository" >&2
+        return 1
+    end
+
+    set -l target (printf '%s\n' $worktree_paths | fzf --preview "eza --tree --level=2 --color=always {} 2>/dev/null" --prompt "worktree> ")
+    if test -z "$target"
+        return
+    end
+
+    cd $target
+end

--- a/home-manager/shell/fish/tests/worktree-switch-test.fish
+++ b/home-manager/shell/fish/tests/worktree-switch-test.fish
@@ -1,0 +1,227 @@
+#!/usr/bin/env fish
+# Behavioral test for worktree_switch.
+#
+# Mirrors worktree-new-test.fish's technique: source the function into a
+# fresh `fish -c "..."` subshell (never into the current process) and drive
+# it against scratch git repos created fresh under `mktemp -d`. Every
+# scratch path is created here and removed at the end; nothing outside a
+# fresh mktemp -d is read or written.
+#
+# The interactive `fzf` picker is stubbed via a fake `fzf` executable placed
+# ahead of $PATH -- the same technique fzf_ghq.test.fish uses to stub
+# yq-go -- so the selection and cancel paths can be driven deterministically
+# without a real terminal.
+#
+# Usage: fish home-manager/shell/fish/tests/worktree-switch-test.fish
+# Exit status: 0 if every assertion passed, 1 otherwise.
+
+set -l func_dir (path resolve (path dirname (status --current-filename))/../functions)
+
+set -g failures 0
+
+function _pass
+    echo "PASS: $argv[1]"
+end
+
+function _fail
+    set -g failures (math $failures + 1)
+    echo "FAIL: $argv[1]"
+end
+
+# Writes a stub `fzf` into $stub_dir that reads its stdin and, when
+# $FZF_STUB_SELECT is set in the invoking environment, echoes the first
+# line back (simulating a selection); otherwise it echoes nothing
+# (simulating the user cancelling the picker with Esc/Ctrl-C).
+function make_fzf_stub -a stub_dir
+    begin
+        echo '#!/usr/bin/env fish'
+        echo 'set -l lines (cat)'
+        echo 'if test -n "$FZF_STUB_SELECT"'
+        echo '    printf "%s\n" $lines[1]'
+        echo 'end'
+    end >"$stub_dir/fzf"
+    chmod +x "$stub_dir/fzf"
+end
+
+# --- 1. syntax check on the touched file -------------------------------------
+
+if fish -n "$func_dir/worktree_switch.fish" 2>/tmp/worktree-switch-test-syntax-err.$fish_pid
+    _pass "fish -n worktree_switch.fish"
+else
+    _fail "fish -n worktree_switch.fish: "(cat /tmp/worktree-switch-test-syntax-err.$fish_pid)
+end
+rm -f /tmp/worktree-switch-test-syntax-err.$fish_pid
+
+# --- 2. zero-worktree case: exit 1, $PWD unchanged, stderr message ----------
+
+set -l zero_root (mktemp -d)
+mkdir -p $zero_root/src
+git init -q $zero_root/src
+git -C $zero_root/src commit -q --allow-empty -m init
+git clone -q --bare $zero_root/src $zero_root/repo.git
+set -l zero_repo_git (path resolve $zero_root/repo.git)
+
+set -l zero_lines (fish -c "
+    source $func_dir/worktree_switch.fish
+    cd $zero_repo_git
+    worktree_switch
+    echo EXIT_STATUS=\$status
+    echo PWD_AFTER=\$PWD
+" 2>/tmp/worktree-switch-test-zero-stderr.$fish_pid)
+
+set -l zero_exit (string replace 'EXIT_STATUS=' '' -- $zero_lines[1])
+set -l zero_pwd (string replace 'PWD_AFTER=' '' -- $zero_lines[2])
+set -l zero_stderr (cat /tmp/worktree-switch-test-zero-stderr.$fish_pid)
+rm -f /tmp/worktree-switch-test-zero-stderr.$fish_pid
+
+if test "$zero_exit" = 1
+    _pass "worktree_switch exits 1 with zero other worktrees"
+else
+    _fail "worktree_switch exit status with zero other worktrees: expected 1, got '$zero_exit'"
+end
+
+if test "$zero_pwd" = "$zero_repo_git"
+    _pass "\$PWD unchanged after zero-worktree failure"
+else
+    _fail "\$PWD after zero-worktree failure: expected '$zero_repo_git', got '$zero_pwd'"
+end
+
+if string match -q '*no worktrees found*' -- $zero_stderr
+    _pass "zero-worktree case prints a stderr message"
+else
+    _fail "zero-worktree case stderr message: expected to mention 'no worktrees found', got '$zero_stderr'"
+end
+
+rm -rf $zero_root
+
+# --- 3. successful selection: stubbed fzf picks the one candidate ----------
+
+set -l sel_root (mktemp -d)
+mkdir -p $sel_root/src
+git init -q $sel_root/src
+git -C $sel_root/src commit -q --allow-empty -m init
+git clone -q --bare $sel_root/src $sel_root/repo.git
+set -l sel_repo_git (path resolve $sel_root/repo.git)
+git -C $sel_repo_git worktree add -q --detach $sel_root/wt1 HEAD >/dev/null 2>&1
+set -l sel_wt1 (path resolve $sel_root/wt1)
+
+set -l sel_stub_dir (mktemp -d)
+make_fzf_stub $sel_stub_dir
+
+set -l sel_lines (fish -c "
+    set -lx PATH $sel_stub_dir \$PATH
+    set -lx FZF_STUB_SELECT 1
+    source $func_dir/worktree_switch.fish
+    cd $sel_repo_git
+    worktree_switch
+    echo EXIT_STATUS=\$status
+    echo PWD_AFTER=\$PWD
+")
+
+set -l sel_exit (string replace 'EXIT_STATUS=' '' -- $sel_lines[1])
+set -l sel_pwd (string replace 'PWD_AFTER=' '' -- $sel_lines[2])
+
+if test "$sel_exit" = 0
+    _pass "worktree_switch exits 0 on a successful fzf selection"
+else
+    _fail "worktree_switch exit status on selection: expected 0, got '$sel_exit'"
+end
+
+if test "$sel_pwd" = "$sel_wt1"
+    _pass "\$PWD after selection is the picked worktree"
+else
+    _fail "\$PWD after selection: expected '$sel_wt1', got '$sel_pwd'"
+end
+
+rm -rf $sel_root $sel_stub_dir
+
+# --- 4. cancel path: stubbed fzf echoes nothing -> no cd, exit 0 -----------
+
+set -l cancel_root (mktemp -d)
+mkdir -p $cancel_root/src
+git init -q $cancel_root/src
+git -C $cancel_root/src commit -q --allow-empty -m init
+git clone -q --bare $cancel_root/src $cancel_root/repo.git
+set -l cancel_repo_git (path resolve $cancel_root/repo.git)
+git -C $cancel_repo_git worktree add -q --detach $cancel_root/wt1 HEAD >/dev/null 2>&1
+
+set -l cancel_stub_dir (mktemp -d)
+make_fzf_stub $cancel_stub_dir
+
+set -l cancel_lines (fish -c "
+    set -lx PATH $cancel_stub_dir \$PATH
+    source $func_dir/worktree_switch.fish
+    cd $cancel_repo_git
+    worktree_switch
+    echo EXIT_STATUS=\$status
+    echo PWD_AFTER=\$PWD
+")
+
+set -l cancel_exit (string replace 'EXIT_STATUS=' '' -- $cancel_lines[1])
+set -l cancel_pwd (string replace 'PWD_AFTER=' '' -- $cancel_lines[2])
+
+if test "$cancel_exit" = 0
+    _pass "worktree_switch exits 0 when the fzf picker is cancelled"
+else
+    _fail "worktree_switch exit status on cancel: expected 0, got '$cancel_exit'"
+end
+
+if test "$cancel_pwd" = "$cancel_repo_git"
+    _pass "\$PWD unchanged after cancelling the picker (no cd happened)"
+else
+    _fail "\$PWD after cancel: expected '$cancel_repo_git', got '$cancel_pwd'"
+end
+
+rm -rf $cancel_root $cancel_stub_dir
+
+# --- 5. failure path: not inside a git repo -> exit 1, $PWD unchanged ------
+
+set -l notrepo_root (mktemp -d)
+set -l notrepo_dir (path resolve $notrepo_root)
+
+if git -C $notrepo_dir rev-parse --show-toplevel >/dev/null 2>&1
+    _fail "precondition violated: $notrepo_dir is unexpectedly inside a git repository, cannot exercise the failure path"
+else
+    set -l notrepo_lines (fish -c "
+        source $func_dir/worktree_switch.fish
+        cd $notrepo_dir
+        worktree_switch
+        echo EXIT_STATUS=\$status
+        echo PWD_AFTER=\$PWD
+    " 2>/tmp/worktree-switch-test-notrepo-stderr.$fish_pid)
+
+    set -l notrepo_exit (string replace 'EXIT_STATUS=' '' -- $notrepo_lines[1])
+    set -l notrepo_pwd (string replace 'PWD_AFTER=' '' -- $notrepo_lines[2])
+    set -l notrepo_stderr (cat /tmp/worktree-switch-test-notrepo-stderr.$fish_pid)
+    rm -f /tmp/worktree-switch-test-notrepo-stderr.$fish_pid
+
+    if test "$notrepo_exit" = 1
+        _pass "worktree_switch exits 1 outside a git repository"
+    else
+        _fail "worktree_switch exit status outside a git repo: expected 1, got '$notrepo_exit'"
+    end
+
+    if test "$notrepo_pwd" = "$notrepo_dir"
+        _pass "\$PWD unchanged after failing outside a git repository"
+    else
+        _fail "\$PWD outside a git repo: expected '$notrepo_dir', got '$notrepo_pwd'"
+    end
+
+    if string match -q '*not inside a git repository*' -- $notrepo_stderr
+        _pass "not-a-git-repo case prints a stderr message"
+    else
+        _fail "not-a-git-repo case stderr message: expected to mention 'not inside a git repository', got '$notrepo_stderr'"
+    end
+end
+
+rm -rf $notrepo_root
+
+# --- summary -----------------------------------------------------------------
+
+if test $failures -eq 0
+    echo "worktree-switch-test: all checks passed"
+    exit 0
+else
+    echo "worktree-switch-test: $failures check(s) failed"
+    exit 1
+end


### PR DESCRIPTION
## Summary
- C-o / `worktree_new` cut new worktrees from `main` at bare-clone time, since `ghq get --bare` never fetches again after cloning; `__fzf_ghq_new_worktree`'s base_ref resolution now does a guarded `git fetch origin main` first (explicit refspec per call, no persisted config, graceful fallback to local refs on fetch failure).
- Adds `worktree_switch`: a narrower, current-repo-only, non-tmux sibling of `fzf_ghq`'s worktree picker for switching between existing worktrees without creating a new one.

## Test plan
- [x] `fish -n` on all 4 touched/new files
- [x] `fzf_ghq_fetch.test.fish` — 8/8 passed (freshness, fetch-failure fallback, no-origin regression)
- [x] `worktree-switch-test.fish` — 11/11 passed (zero-worktree, selection, cancel, outside-a-repo)
- [x] Pre-existing suites unaffected: `fzf_ghq.test.fish` 15/15, `worktree-new-test.fish` all passing