### PR TITLE
feat(ai-prompts): strengthen code-comment discipline in standard_practices

### DIFF
--- a/home-manager/ai-tools/ai-prompts/CLAUDE.md
+++ b/home-manager/ai-tools/ai-prompts/CLAUDE.md
@@ -236,8 +236,14 @@ the wrong choice is expensive to undo, and when you ask, use AskUserQuestion onc
 options.
 
 Write user-facing output in the language the active tool or session directive specifies, defaulting to English
-when none is configured. Keep timestamps and drift-prone counts out of documentation, and comment only what
-the code cannot show.
+when none is configured. Keep timestamps and drift-prone counts out of documentation.
+
+Default to writing no comments in code you produce, and add one only when it carries a WHY the code itself
+cannot show: a hidden constraint, a subtle invariant, a workaround for a specific bug, or behavior that would
+surprise the next reader, never a WHAT that restates what the identifiers already say. If removing it would
+not leave a future reader confused, delete it. Only Claude Code's own CLI defaults to this natively; opencode
+and Codex have no equivalent of their own, so this paragraph is the only place either one receives the rule
+at all.
 </standard_practices>
 
 <failure_handling>


### PR DESCRIPTION
## Summary
- Replace the buried "comment only what the code cannot show" clause in `CLAUDE.md`'s `<standard_practices>` with a dedicated paragraph: default to no comments, add one only for a WHY the code can't show (hidden constraint, subtle invariant, bug workaround, surprising behavior), never a WHAT.
- CLAUDE.md is the single source for Claude Code, opencode, and Codex; only Claude Code's own CLI has an equivalent built-in default, so this is the only place opencode and Codex receive comment-minimization guidance at all.

## Test plan
- [x] `home-manager/ai-tools/ai-prompts/verify-prompts.sh` — 12/12 checks, exit 0
- [x] Six-dimension review (quality, security, design, docs, performance, test-gate coverage) — no critical/warning findings
- [x] Deployed via `darwin-rebuild switch` and byte-checked: `~/.claude/CLAUDE.md` and `~/.opencode/CLAUDE.md` both carry the new paragraph at line 241