### PR TITLE
fix(git): drop trailing slash from .claude ignore pattern

### DIFF
--- a/home-manager/vcs/git/default.nix
+++ b/home-manager/vcs/git/default.nix
@@ -32,7 +32,7 @@
     ".serena/"
     ".sisyphus/"
     ".cache/"
-    ".claude/"
+    ".claude"
     "coverage.out"
     ".auth/"
     "playwright-report/"


### PR DESCRIPTION
## Summary
- Global gitignore entry `.claude/` only matches directories; a symlinked `.claude` (e.g. from dotfile management) is untracked by that pattern and would leak into `git status`. Dropping the trailing slash matches `.claude` regardless of file type.

## Test plan
- [x] gitleaks pre-commit hook passed on the change