### PR TITLE
feat(homebrew): add amical cask

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -9,6 +9,7 @@
     "docker-credential-helper"
   ];
   homebrew.casks = [
+    "amical"
     "aquaskk"
     "cleanshot"
     "claude"


### PR DESCRIPTION
## Summary
- Add `amical` (https://formulae.brew.sh/cask/amical) to the declarative Homebrew cask list

## Test plan
- N/A (config-only change; will be applied on next darwin-rebuild)