### PR TITLE
Add cold-read skill and reflect prose-discipline essence into CLAUDE.md

### DIFF
--- a/home-manager/ai-tools/agent-skills/skills/cold-read/SKILL.md
+++ b/home-manager/ai-tools/agent-skills/skills/cold-read/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: cold-read
+description: A context-free reviewer reads durable prose as its real audience; the writer applies surviving cuts. Use at task completion whenever docs, README, comment blocks, commit messages, or PR/issue bodies were written or revised.
+version: 1.0.0
+---
+
+# Cold read
+
+The writer cannot measure its own prose — the context that produced it makes every sentence feel necessary.
+A fresh reader with none of that context measures it instead. Its report is evidence to weigh, not an edit
+script to apply verbatim.
+
+## Procedure
+
+1. Collect the task's durable prose. A non-file artifact (a PR body, a commit message) goes into a scratch
+   file first, one per artifact.
+2. Give the reviewer only what the artifact's real reader will have. For docs and code comments: the working
+   tree, never the diff or the conversation that produced it — a comment that only reads clearly next to the
+   diff is the defect this test catches. For a PR or commit body: the body plus its diff. Nothing from this
+   session.
+3. Dispatch one fresh agent via the Agent tool with a subagent_type other than `fork` — a fork inherits this
+   conversation's context, which is exactly what this test must exclude. Give it the reviewer prompt below
+   verbatim, filling only `{paths}` and the audience line (the artifact's real reader: "a developer new to
+   this repo", "the human reviewing this PR"). Anything more is context that reader will not have, and it
+   blinds the test.
+4. Apply the report: a cut lands unless it drops a reader decision, precondition, or warning — keeping a span
+   requires naming that loss, and "adds nuance" is the writer's bias, not a loss. Re-anchor each reported
+   confusion to a fact the reader can see; add prose only for a confusion the reviewer actually raised or a
+   fact the reader can reach nowhere else. If most of a passage is cut, rewrite it from the survivors rather
+   than patching around the cuts. For style-level repairs, apply technical-writing's rules, not the
+   reviewer's prose.
+5. Load-bearing docs (README, architecture notes, onboarding) get three independent reviewer dispatches: a
+   span every one of them cuts is dead weight; a confusion any one of them raises needs an anchor in the text.
+
+## Reviewer prompt template
+
+    You are reading this material for the first time. You know nothing about the
+    conversation, task, or commits that produced it. Audience to embody: {audience line}.
+
+    Read: {paths}. You may read other repository files to verify claims, but read no
+    git history and, unless a diff is listed above, no diffs.
+
+    Report three lists with file:line spans:
+    1. Probe — what is each artifact for, and what would you do differently because
+       you read it? Cite only what you read.
+    2. Confusions — every place you stopped, reread, guessed, or hit a referent you
+       cannot resolve ("the above fix", "now", "this approach").
+    3. Cuts — every span whose deletion loses nothing your audience would miss; a span
+       earns its place by changing what the reader does or believes. Propose no
+       additions; name gaps under Confusions instead.
+
+    Report to an editor, not a person: no praise, no hedging, no summary.
+
+## Related
+
+- [technical-writing](../technical-writing/SKILL.md) — the style rules to apply when acting on a reviewer's
+  Confusions or Cuts

--- a/home-manager/ai-tools/agent-skills/skills/technical-writing/SKILL.md
+++ b/home-manager/ai-tools/agent-skills/skills/technical-writing/SKILL.md
@@ -1,13 +1,34 @@
 ---
 name: technical-writing
-description: Use when writing a blog post, technical article, or tutorial for external audiences, in English or Japanese — includes a Japanese prose-quality ruleset and a long-form structure ruleset for books and serials.
-version: 3.0.0
+description: Use when writing a blog post, technical article, tutorial, report, PR/issue body, or doc/comment prose, in English or Japanese — includes general prose mechanics, a Japanese prose-quality ruleset, and a long-form structure ruleset for books and serials.
+version: 3.1.0
 ---
 
 Structured patterns for writing technical blogs, articles, and tutorials that communicate technical concepts
 to external audiences, in English or Japanese. Pick the article type that matches the reader's need below,
 apply the language-specific conventions, and for book chapters or serials layer the long-form structure
-ruleset on top.
+ruleset on top. The general prose mechanics below apply to any human-facing writing, not only the article
+types — reach for them alone when revising a report, a PR/issue body, or documentation prose.
+
+## General prose mechanics
+
+Classify each passage before writing it, and do not mix the two in one passage:
+
+- **Procedural** — tells the reader what to do; imperative mood, one instruction per sentence.
+- **Descriptive** — explains what a thing is or does; no imperative, one new point per sentence.
+
+Put the condition before the command ("If the build fails, read the log" — a trailing condition gets dropped
+by a skimming reader). Describe an action with a verb, not a nominalization ("compress the file", not
+"perform compression"). A requirement is "must"; a capability is "can"; do not write "should" in
+instructions — readers treat it as optional. Never convert genuine uncertainty into assertion: a hedge that
+carries real epistemic content (an unverified fact, an inference, a reader's likely doubt) keeps its
+uncertainty, and is deleted only once the text grounds the claim. Delete filler — announcements ("In this
+section..."), empty intensifiers ("robust", "comprehensive"), padding connectives — by removing it, not by
+rephrasing around it.
+
+The Japanese-specific rules under Language guidelines extend this same rigor (argument structure, redundancy,
+LLM-tell avoidance) with additional detail; apply them together when writing Japanese. To test whether any of
+this prose actually reads clearly to its intended audience once written, see [cold-read](../cold-read/SKILL.md).
 
 ## Article types
 
@@ -379,6 +400,8 @@ Reduce the bloat that accumulates across a long piece:
 
 ## Related
 
+- [cold-read](../cold-read/SKILL.md) — dispatch a context-free reviewer to test whether the written prose
+  actually reads clearly to its audience
 - [serena-usage](../serena-usage/SKILL.md) — symbol operations for extracting code examples from projects
 - [context7-usage](../context7-usage/SKILL.md) — library documentation lookup for accurate technical
   references

--- a/home-manager/ai-tools/ai-prompts/CLAUDE.md
+++ b/home-manager/ai-tools/ai-prompts/CLAUDE.md
@@ -116,6 +116,7 @@ delegation failed — never present an unanswered question as an absence of find
 Tag every finding: verified (you ran a command or read the line and can cite it), inferred (follows from
 something verified but unobserved), assumed (otherwise). Never give a numeric self-assessment — confidence
 score, percent complete, dev-hour figure — because none has a derivation; state the observable condition.
+A dismissal is a claim too: "probably fine" needs the same evidence backing it as "broken" would.
 
 A zero exit is the most over-trusted signal here. It proves the harness ran, not that the check ran:
 
@@ -198,7 +199,8 @@ govern costs its full body on every later request in the session.
 | Editing Common Lisp, Emacs Lisp, Scheme, Clojure, Fennel, or Janet source | paredit-cli |
 | Nix, flake, or Home Manager work | nix-ecosystem |
 | Needing a library's current API, version behavior, or migration notes | context7-usage |
-| Writing prose for an external audience | technical-writing, technical-documentation |
+| Writing prose for an external audience, a report, or documentation | technical-writing, technical-documentation |
+| Docs, README, comment blocks, commit messages, or PR/issue bodies were written or revised, at task completion | cold-read |
 | Other language or domain work | the matching skill in the injected listing |
 
 Content belongs in exactly one layer: a fact needed every session stays here, a rule decidable mechanically


### PR DESCRIPTION
## Summary
- Add a `cold-read` skill: dispatches a context-free reviewer agent to test written docs/comments/PR bodies against their real audience, adapted from motoki317/dotfiles.
- Add general English prose mechanics (procedural/descriptive classification, condition-before-command, requirement/capability/uncertainty precision, filler removal) to `technical-writing/SKILL.md`, broadening its scope beyond blog articles to reports, PR/issue bodies, and docs.
- Add one evidence-discipline line to `CLAUDE.md` ("a dismissal is a claim too") and a load_table trigger routing doc/README/PR-body completion to `cold-read`.

## Test plan
- [x] `git commit` pre-commit hook (gitleaks) ran clean
- [x] Confirmed `sources.custom` auto-discovers skill directories (no `.nix` registry needed for the new `cold-read` skill)
- [ ] `home-manager switch` to confirm the new skill and updated CLAUDE.md build and land under `~/.claude/`