### PR TITLE
Disable swift-mode: emacs-unstable-31.1-rc1 installer aborts

### DIFF
--- a/home-manager/editor/packages/epkgs/packages/language/default.nix
+++ b/home-manager/editor/packages/epkgs/packages/language/default.nix
@@ -80,7 +80,9 @@ with epkgs;
   slim-mode
   solidity-mode
   ssh-config-mode
-  swift-mode
+  # swift-mode: disabled, emacs-unstable-31.1-rc1's elpa2nix installer aborts
+  # (SIGABRT) after byte-compiling swift-mode-20260801.1244, before writing
+  # the package; re-enable once emacs-unstable or the swift-mode snapshot moves.
   syslog-mode
   systemd-mode
   terraform-mode


### PR DESCRIPTION
## Summary
- `emacs-swift-mode-20260801.1244.drv` aborts (SIGABRT) in elpa2nix's install step, right after successfully byte-compiling all 9 files — a crash inside `emacs-unstable-31.1-rc1`'s installer, not in swift-mode's elisp.
- Comments out `swift-mode` in `home-manager/editor/packages/epkgs/packages/language/default.nix` with a note on why, and when to re-enable.

## Test plan
- [x] `nix build .#darwinConfigurations.M4-Max.system --dry-run` — evaluates cleanly, `emacs-swift-mode-*.drv` no longer appears in the build plan.
- [ ] Full `darwin-system` build to confirm the downstream chain (`emacs-unstable-with-packages` → `home-manager-generation` → `darwin-system`) completes — running, not yet finished.