### PR TITLE
Disable jemalloc for tmux on Darwin

### DIFF
--- a/home-manager/advanced.nix
+++ b/home-manager/advanced.nix
@@ -12,6 +12,7 @@ let
   isDarwin = lib.hasSuffix "-darwin" system;
 
   editorOverlay = import ./editor/overlay.nix { inherit emacs-overlay; };
+  shellOverlay = import ./shell/overlay.nix;
   sketchybarOverlay = import ./mac/sketchybar/overlay.nix;
   pkgs = import nixpkgs {
     inherit system;
@@ -62,10 +63,11 @@ in
   };
 
   nixpkgs.config.allowUnfree = true;
-  # sketchybarOverlay must be listed here (home-manager's own pkgs), not only in
-  # the host overlays: without useGlobalPkgs, HM ignores the host's pkgs and
-  # builds programs.sketchybar.package from this nixpkgs instance.
-  nixpkgs.overlays = editorOverlay ++ sketchybarOverlay ++ [ mcp-servers-nix.overlays.default ];
+  # sketchybarOverlay and shellOverlay must be listed here (home-manager's own
+  # pkgs), not only in the host overlays: without useGlobalPkgs, HM ignores the
+  # host's pkgs and builds programs.sketchybar.package / programs.tmux.package
+  # from this nixpkgs instance.
+  nixpkgs.overlays = editorOverlay ++ shellOverlay ++ sketchybarOverlay ++ [ mcp-servers-nix.overlays.default ];
 
   programs.nixvim.nixpkgs.source = nixpkgs;
 

--- a/home-manager/shell/overlay.nix
+++ b/home-manager/shell/overlay.nix
@@ -4,5 +4,14 @@
     direnv = prev.direnv.overrideAttrs (_: {
       doCheck = false;
     });
+
+    # tmux 3.7c's configure now requires an explicit jemalloc choice on Darwin
+    # (macOS calloc doesn't reliably zero); nixpkgs' package.nix doesn't pass
+    # either flag yet. jemalloc isn't a buildInput here, so disable it.
+    tmux = prev.tmux.overrideAttrs (old: {
+      configureFlags = old.configureFlags ++ prev.lib.optionals prev.stdenv.hostPlatform.isDarwin [
+        "--disable-jemalloc"
+      ];
+    });
   })
 ]


### PR DESCRIPTION
## Summary
- tmux 3.7c's configure now requires an explicit jemalloc choice on Darwin (macOS calloc doesn't reliably zero); nixpkgs' package.nix doesn't pass either flag yet, so add `--disable-jemalloc` via overrideAttrs on Darwin.
- Wire the new `shellOverlay` into home-manager's own nixpkgs instance (`advanced.nix`) so the override actually applies — home-manager builds `programs.tmux.package` from that instance, not just the host overlays.

## Test plan
- [ ] `nix flake check`
- [ ] Rebuild home-manager on Darwin and confirm tmux builds without the jemalloc configure failure