### PR TITLE
sketchybar: replace pmset noidle sleep-prevent toggle with sudo pmset -a disablesleep

### DIFF
--- a/home-manager/mac/sketchybar/default.nix
+++ b/home-manager/mac/sketchybar/default.nix
@@ -136,43 +136,32 @@ let
     fi
   '';
 
-  # Sleep-prevention (pmset noidle) state file, shared by both scripts below.
-  # PID-file (not `pgrep -f pmset`) so a user-launched pmset elsewhere is never
-  # touched by the toggle. Session-scoped: doesn't survive logout/reboot, by design (no sudo,
-  # since `pmset noidle` only holds an IOPMAssertion like caffeinate -- it does not touch
-  # system-wide power settings and needs no elevated privileges).
-  sleepPreventPidfile = "$HOME/.cache/sketchybar_pmset_noidle.pid";
-
-  # Sleep-prevention display plugin script (reflects the actual pmset process state).
-  # Only trusts the pidfile if that PID is still actually a pmset process, since PIDs
-  # get reused by macOS and a stale entry could otherwise point at an unrelated process.
+  # Sleep-prevention display plugin script: reflects system-wide disablesleep state.
+  # `pmset -g`'s "System-wide power settings:" block prints the setter keyword
+  # "disablesleep" as "SleepDisabled" -- the getter and setter names differ.
   sleepPreventPlugin = pkgs.writeShellScript "sleep_prevent.sh" ''
-    PIDFILE="${sleepPreventPidfile}"
+    STATE=$(pmset -g | awk '/SleepDisabled/ {print $2}')
 
-    if [ -f "$PIDFILE" ] && [ "$(ps -p "$(cat "$PIDFILE")" -o comm= 2>/dev/null)" = "pmset" ]; then
+    if [ "$STATE" = "1" ]; then
       sketchybar --set "$NAME" icon.color=${colors.orange}
     else
       sketchybar --set "$NAME" icon.color=${colors.comment}
     fi
   '';
 
-  # Sleep-prevention toggle click script: starts/stops a detached `pmset noidle` process (no sudo)
+  # Sleep-prevention toggle click script: flips system-wide sleep via `sudo pmset -a
+  # disablesleep`. Requires the NOPASSWD sudoers grant in nix-darwin/config/security.nix
+  # (scoped to exactly these two invocations), since this click_script has no TTY to
+  # answer a password/Touch ID prompt. No double-click lock needed: unlike the previous
+  # `pmset noidle` background-process approach, this is one synchronous idempotent
+  # command with no process to orphan -- a race at worst runs two toggles back to back.
   sleepPreventTogglePlugin = pkgs.writeShellScript "sleep_prevent_toggle.sh" ''
-    PIDFILE="${sleepPreventPidfile}"
-    LOCKDIR="$PIDFILE.lock"
-    mkdir -p "$(dirname "$PIDFILE")"
+    STATE=$(pmset -g | awk '/SleepDisabled/ {print $2}')
 
-    # Guard against a rapid double-click racing two toggles and orphaning a pmset process
-    mkdir "$LOCKDIR" 2>/dev/null || exit 0
-    trap 'rmdir "$LOCKDIR" 2>/dev/null' EXIT
-
-    if [ -f "$PIDFILE" ] && [ "$(ps -p "$(cat "$PIDFILE")" -o comm= 2>/dev/null)" = "pmset" ]; then
-      kill "$(cat "$PIDFILE")" 2>/dev/null
-      rm -f "$PIDFILE"
+    if [ "$STATE" = "1" ]; then
+      sudo pmset -a disablesleep 0
     else
-      nohup pmset noidle >/dev/null 2>&1 &
-      disown
-      echo "$!" > "$PIDFILE"
+      sudo pmset -a disablesleep 1
     fi
 
     sketchybar --update
@@ -313,8 +302,8 @@ let
                       icon.color="$GREEN" \
                       label.drawing=off
 
-    # Sleep prevention toggle (pmset noidle, no sudo required; update_freq=5 since it's a cheap
-    # kill -0 check, not a heavier poll like the 1s-interval items below). Icon-only (no label,
+    # Sleep prevention toggle (sudo pmset -a disablesleep; update_freq=5 since it's a cheap
+    # `pmset -g` read, not a heavier poll like the 1s-interval items below). Icon-only (no label,
     # matching power_icon) to keep the right-side item group narrow enough to clear the notch.
     sketchybar --add item sleep_prevent right \
                 --set sleep_prevent \

--- a/nix-darwin/config/security.nix
+++ b/nix-darwin/config/security.nix
@@ -1,5 +1,21 @@
+{ username }:
 {
   security.pam.services.sudo_local.enable = true;
   security.pam.services.sudo_local.touchIdAuth = true;
   security.pam.services.sudo_local.reattach = true;
+
+  # NOPASSWD, scoped to exactly these two invocations, so sketchybar's
+  # non-interactive click_script (no TTY, can't satisfy the Touch ID prompt
+  # above) can toggle system-wide sleep without a broader sudo grant.
+  security.sudo.extraConfig = ''
+    ${username} ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 0, /usr/bin/pmset -a disablesleep 1
+  '';
+
+  # One-shot migration cleanup: the sketchybar sleep_prevent toggle used to spawn a
+  # detached `pmset noidle` process (tracked by a PID file in home-manager/mac/sketchybar).
+  # That mechanism is replaced by disablesleep above, so a process left running from
+  # the old toggle would otherwise be orphaned -- untracked and unkillable from the UI.
+  system.activationScripts.killStrayPmsetNoidle.text = ''
+    /usr/bin/pkill -f 'pmset noidle' || true
+  '';
 }

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -10,7 +10,7 @@ let
   homebrew = import ./config/homebrew.nix;
   networking = import ./config/networking.nix;
   nix = import ./config/nix.nix;
-  security = import ./config/security.nix;
+  security = import ./config/security.nix { inherit username; };
   services = import ./config/services { inherit pkgs emacsLib; };
   spotlight = import ./config/spotlight.nix;
   system = import ./config/system.nix { inherit username; };


### PR DESCRIPTION
## Summary
- Replaces the sketchybar `sleep_prevent` toggle's mechanism from session-scoped `pmset noidle` (no sudo) to system-wide `sudo pmset -a disablesleep <0|1>`, per explicit requirements discussion.
- Adds a NOPASSWD sudoers grant (`security.sudo.extraConfig` in `nix-darwin/config/security.nix`) scoped to exactly `pmset -a disablesleep 0`/`1` — no wildcard — since sketchybar's `click_script` runs with no TTY.
- Adds a one-shot `system.activationScripts` cleanup to kill any `pmset noidle` process orphaned by the old mechanism.

## Test plan
- [x] `nix flake check` — exit 0 (run twice; `darwinConfigurations.M4-Max` evaluation confirmed via home-manager profile eval warnings, `checks.aarch64-darwin.treefmt` freshly built both times)
- [x] `visudo -c -f` on the actual rendered sudoers content — parsed OK
- [x] `nix build` on the realized `sleep_prevent.sh` / `sleep_prevent_toggle.sh` derivations (exercises `writeShellScript`'s `bash -n` checkPhase) — success
- [x] `shellcheck -s bash` on both realized scripts — clean
- [ ] `darwin-rebuild switch` on the real M4-Max host + live toggle click, confirming the sudoers grant is non-interactive and the icon reflects real `SleepDisabled` state (manual, not yet run — no automated harness for sketchybar/nix-darwin activation exists in this repo)