### PR TITLE
nix-darwin: add stablyai/orca tap and Orca ADE cask

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -8,6 +8,9 @@
     "pdfpc"
     "docker-credential-helper"
   ];
+  homebrew.taps = [
+    "stablyai/orca"
+  ];
   homebrew.casks = [
     "amical"
     "aquaskk"
@@ -28,6 +31,7 @@
     "sf-symbols"
     "slack"
     "slite"
+    "stablyai/orca/orca"
     "sublime-text"
   ];
 }


### PR DESCRIPTION
## Summary
- Adds the third-party `stablyai/orca` Homebrew tap and its cask (`stablyai/orca/orca`) to `nix-darwin/config/homebrew.nix`, installing Orca (onorca.dev), the multi-agent coding IDE.
- Uses the fully-qualified cask token deliberately: the official, untapped `orca` cask name is already taken by an unrelated, deprecated tool (Plotly Orca chart-image generator, fails Gatekeeper, removal scheduled 2026-09-01) — confirmed via the full Homebrew cask catalog, no entry anywhere references orca.build/onorca.
- Verified the tap is real: `stablyai/orca` on GitHub contains `Casks/orca.rb` matching the product description at onorca.dev.

## Test plan
- [x] `nix-instantiate --parse` on the changed file — OK
- [x] `nix eval .#darwinConfigurations.M4-Max.config.homebrew.{taps,casks}` — renders the expected Brewfile lines (`tap "stablyai/orca"`, `cask "stablyai/orca/orca", trusted: true`)
- [x] `nix flake check` — exit 0
- [ ] `darwin-rebuild switch` on the real M4-Max host to actually install the cask (manual, not run this session)