### PR TITLE
home-manager: remove fish tmux auto-attach on shell init

### DIFF
--- a/home-manager/shell/fish/default.nix
+++ b/home-manager/shell/fish/default.nix
@@ -15,10 +15,6 @@
   programs.fish.enable = true;
 
   programs.fish.shellInit = ''
-    if type -q tmux && test -z $TMUX
-        tmux attach-session || tmux new-session
-    end
-
     set fish_greeting
 
     # macOS: fish launched from launchd may not inherit TMPDIR


### PR DESCRIPTION
## Summary
- Removes the `tmux attach-session || tmux new-session` auto-attach block from fish's `shellInit`, so fish no longer forces every new shell into a tmux session.

## Test plan
- [ ] `nix flake check`