### PR TITLE
nix-darwin: enable tailscale on M4-Max

### DIFF
--- a/nix-darwin/config/services/default.nix
+++ b/nix-darwin/config/services/default.nix
@@ -4,6 +4,7 @@ let
   darwin-vz = import ./darwin-vz;
   dnsmasq = import ./dnsmasq;
   nextdns = import ./nextdns;
+  tailscale = import ./tailscale;
 in
 {
   imports = [
@@ -11,5 +12,6 @@ in
     darwin-vz
     dnsmasq
     nextdns
+    tailscale
   ];
 }

--- a/nix-darwin/config/services/tailscale/default.nix
+++ b/nix-darwin/config/services/tailscale/default.nix
@@ -1,0 +1,3 @@
+{
+  services.tailscale.enable = true;
+}


### PR DESCRIPTION
## Summary
- Enable Tailscale (mesh VPN) on the M4-Max nix-darwin host via nix-darwin's built-in `services.tailscale` module, following the existing `dnsmasq`/`nextdns` single-file module pattern.
- CLI-only (`tailscale`/`tailscaled`), no Homebrew GUI cask — chosen so the daemon stays declaratively managed and version-pinned through the flake.

## Test plan
- [x] `nix build .#checks.aarch64-darwin.treefmt --no-link` — exit 0, 264 files formatted, 0 changed
- [x] `nix build .#darwinConfigurations.M4-Max.system --no-link` — exit 0; closure includes `tailscale-1.102.3`, `com.tailscale.tailscaled.plist`, `/etc/resolver/ts.net`
- [ ] `darwin-rebuild switch` + `tailscale up` on the actual Mac (manual, not run here)