### PR TITLE
home-manager: add /run/current-system/sw/bin to fish PATH

### DIFF
--- a/home-manager/shell/fish/default.nix
+++ b/home-manager/shell/fish/default.nix
@@ -33,6 +33,10 @@
     if test -d /etc/profiles/per-user/(whoami)/bin
         fish_add_path /etc/profiles/per-user/(whoami)/bin
     end
+
+    if test -d /run/current-system/sw/bin
+        fish_add_path /run/current-system/sw/bin
+    end
   '';
 
   programs.fish.shellInitLast = ''


### PR DESCRIPTION
## Summary
- fish's `shellInit` only added `/etc/profiles/per-user/<user>/bin` (home-manager profile) to PATH; it never sourced nix-darwin's system `set-environment`, so system-level packages installed via `services.*` (e.g. `services.tailscale.enable` from #94) were invisible in fish and to `sudo`.
- Adds `fish_add_path /run/current-system/sw/bin` alongside the existing per-user profile line.

## Test plan
- [x] `nix build ".#darwinConfigurations.M4-Max.system" --no-link` — exit 0, produced `/nix/store/l4p5ihqypx5ayrsygmv96ncjpp9k0f1i-darwin-system-26.11.4cff07d`
- [ ] `darwin-rebuild switch` on M4-Max, open a new fish shell, confirm `tailscale` resolves and `sudo tailscale up` works without a full path