### PR TITLE
sketchybar: add tailscale serve toggle for Mediator

### DIFF
--- a/home-manager/mac/sketchybar/default.nix
+++ b/home-manager/mac/sketchybar/default.nix
@@ -167,6 +167,34 @@ let
     sketchybar --update
   '';
 
+  # Tailscale-serve display plugin script: reflects whether Mediator
+  # (127.0.0.1:43100) is currently proxied onto the tailnet.
+  tailscaleServePlugin = pkgs.writeShellScript "tailscale_serve.sh" ''
+    TAILSCALE="/run/current-system/sw/bin/tailscale"
+
+    if "$TAILSCALE" serve status 2>/dev/null | grep -q '43100'; then
+      sketchybar --set "$NAME" icon.color=${colors.green}
+    else
+      sketchybar --set "$NAME" icon.color=${colors.comment}
+    fi
+  '';
+
+  # Tailscale-serve toggle click script: flips `tailscale serve` for Mediator
+  # on/off. Requires the NOPASSWD sudoers grant in nix-darwin/config/security.nix
+  # (scoped to exactly these two invocations), since this click_script has no
+  # TTY to answer a password/Touch ID prompt.
+  tailscaleServeTogglePlugin = pkgs.writeShellScript "tailscale_serve_toggle.sh" ''
+    TAILSCALE="/run/current-system/sw/bin/tailscale"
+
+    if "$TAILSCALE" serve status 2>/dev/null | grep -q '43100'; then
+      sudo "$TAILSCALE" serve --https=443 off
+    else
+      sudo "$TAILSCALE" serve --bg 43100
+    fi
+
+    sketchybar --update
+  '';
+
   sketchybarConfig = ''
     #!/bin/bash
 
@@ -315,6 +343,18 @@ let
                       script="${sleepPreventPlugin}" \
                       click_script="${sleepPreventTogglePlugin}"
 
+    # Tailscale-serve toggle for Mediator (127.0.0.1:43100). Icon-only, matching
+    # sleep_prevent, in the same power_bracket group.
+    sketchybar --add item tailscale_serve right \
+                --set tailscale_serve \
+                      icon=󰛳 \
+                      icon.font="Hack Nerd Font:Bold:14.0" \
+                      icon.color="$COMMENT" \
+                      label.drawing=off \
+                      update_freq=5 \
+                      script="${tailscaleServePlugin}" \
+                      click_script="${tailscaleServeTogglePlugin}"
+
     sketchybar --add item separator_power right \
                 --set separator_power \
                       icon=│ \
@@ -382,7 +422,7 @@ let
                       background.corner_radius=10 \
                       background.height=32
 
-    sketchybar --add bracket power_bracket power_icon battery sleep_prevent \
+    sketchybar --add bracket power_bracket power_icon battery sleep_prevent tailscale_serve \
                 --set power_bracket \
                       background.color="$CURRENT_LINE" \
                       background.corner_radius=10 \

--- a/nix-darwin/config/security.nix
+++ b/nix-darwin/config/security.nix
@@ -7,8 +7,13 @@
   # NOPASSWD, scoped to exactly these two invocations, so sketchybar's
   # non-interactive click_script (no TTY, can't satisfy the Touch ID prompt
   # above) can toggle system-wide sleep without a broader sudo grant.
+  #
+  # Same rationale for the tailscale serve pair: sketchybar's toggle needs to
+  # start/stop serving Mediator (127.0.0.1:43100) over the tailnet without a
+  # TTY. Scoped to exactly these two invocations, not a `tailscale serve *`
+  # wildcard, so the grant can't be reused to serve an arbitrary port.
   security.sudo.extraConfig = ''
-    ${username} ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 0, /usr/bin/pmset -a disablesleep 1
+    ${username} ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 0, /usr/bin/pmset -a disablesleep 1, /run/current-system/sw/bin/tailscale serve --bg 43100, /run/current-system/sw/bin/tailscale serve --https=443 off
   '';
 
   # One-shot migration cleanup: the sketchybar sleep_prevent toggle used to spawn a


### PR DESCRIPTION
## Summary
- Adds a sketchybar item that starts/stops `tailscale serve --bg 43100`, exposing the local Mediator app (127.0.0.1:43100) over the tailnet at https://takeos-macbook-pro.tail534d75.ts.net. Mirrors the existing `sleep_prevent` item's pattern exactly (`script=` for state display, `click_script=` for the toggle, `sketchybar --update` to force a redraw).
- Adds a NOPASSWD sudoers grant in `nix-darwin/config/security.nix`, scoped to exactly the two invocations the toggle needs (`tailscale serve --bg 43100` and `tailscale serve --https=443 off`, not a wildcard), since the click_script has no TTY to answer a password/Touch ID prompt.

## Test plan
- [x] `nix build ".#darwinConfigurations.M4-Max.system" --no-link` — exit 0, produced `/nix/store/v0avk6svrc8w56l0rfrw9qvvsm2nfhkx-darwin-system-26.11.4cff07d`
- [ ] `darwin-rebuild switch` on M4-Max, confirm the new icon renders next to `sleep_prevent` and toggles tailscale serve on click