### PR TITLE
Remove metabase-mcp server from shared MCP config

### DIFF
--- a/home-manager/ai-tools/shared/default.nix
+++ b/home-manager/ai-tools/shared/default.nix
@@ -17,9 +17,6 @@ rec {
         type = "http";
         url = "https://mcp.deepwiki.com/mcp";
       };
-      metabase-mcp = {
-        command = "${nurPkgs.metabase-mcp}/bin/metabase-mcp";
-      };
     };
 
   mcpServerToOpencode =


### PR DESCRIPTION
## Summary
- Remove the `metabase-mcp` entry from the shared `mcpServers` definition (`home-manager/ai-tools/shared/default.nix`); the server was failing to connect (MCP error -32000: Connection closed) and is no longer needed.

## Test plan
- [x] `nix-instantiate --parse home-manager/ai-tools/shared/default.nix` succeeds
- [x] No remaining references to `metabase-mcp` / `metabase` elsewhere in the repo