### PR TITLE
fish: self-heal stale KITTY_INSTALLATION_DIR before kitty integration sources it

### DIFF
--- a/home-manager/shell/fish/default.nix
+++ b/home-manager/shell/fish/default.nix
@@ -37,6 +37,26 @@
     if test -d /run/current-system/sw/bin
         fish_add_path /run/current-system/sw/bin
     end
+
+    # KITTY_INSTALLATION_DIR is set once by kitty at process launch and then
+    # frozen into tmux's long-lived environment; a later kitty rebuild moves
+    # the Nix store path and GC can remove the old one, so re-derive it from
+    # the kitty currently on PATH before home-manager's fish integration
+    # sources $KITTY_INSTALLATION_DIR/shell-integration/fish/vendor_conf.d.
+    if set -q KITTY_INSTALLATION_DIR; and not test -d "$KITTY_INSTALLATION_DIR"
+        set -l kitty_bin (command -v kitty)
+        set -l candidate
+        if test -n "$kitty_bin"
+            set -l resolved (realpath "$kitty_bin")
+            set -l root (string replace -r '/Applications/kitty\.app/Contents/MacOS/kitty$' "" $resolved)
+            set candidate "$root/Applications/kitty.app/Contents/Resources/kitty"
+        end
+        if test -n "$candidate"; and test -d "$candidate"
+            set -gx KITTY_INSTALLATION_DIR $candidate
+        else
+            set -e KITTY_INSTALLATION_DIR
+        end
+    end
   '';
 
   programs.fish.shellInitLast = ''


### PR DESCRIPTION
## Summary
- kitty sets `KITTY_INSTALLATION_DIR` once at process launch; tmux freezes that value into long-lived panes, so a later kitty rebuild (new Nix store path) plus GC of the old path leaves the env var dangling.
- home-manager's fish kitty-integration block unconditionally sources `$KITTY_INSTALLATION_DIR/shell-integration/fish/vendor_conf.d/kitty-shell-integration.fish`, which then errors with "No such file or directory" on every new fish shell in an affected tmux pane.
- Adds a guard to `programs.fish.shellInit` (runs before that block) that re-resolves the install dir from the `kitty` binary currently on `$PATH` when the existing value is stale, or unsets the var cleanly if kitty can't be resolved.

## Test plan
- [x] `fish -n` syntax check on the extracted snippet
- [x] Functional test: stale path repaired to the current, valid kitty store path; the actual upstream `kitty-shell-integration.fish` then sources without error
- [x] Functional test: kitty unresolvable → variable cleanly unset (no downstream error)
- [x] `nix-instantiate --parse` on the edited file
- [x] `nix build .#darwinConfigurations.M4-Max.system` — full build, exit 0; inspected the built `config.fish` output to confirm the guard appears before the kitty-sourcing block