### PR TITLE
sketchybar: make sleep-prevent toggle one-way (disablesleep 1 only)

### DIFF
--- a/home-manager/mac/sketchybar/default.nix
+++ b/home-manager/mac/sketchybar/default.nix
@@ -149,20 +149,15 @@ let
     fi
   '';
 
-  # Sleep-prevention toggle click script: flips system-wide sleep via `sudo pmset -a
-  # disablesleep`. Requires the NOPASSWD sudoers grant in nix-darwin/config/security.nix
-  # (scoped to exactly these two invocations), since this click_script has no TTY to
-  # answer a password/Touch ID prompt. No double-click lock needed: unlike the previous
-  # `pmset noidle` background-process approach, this is one synchronous idempotent
-  # command with no process to orphan -- a race at worst runs two toggles back to back.
-  sleepPreventTogglePlugin = pkgs.writeShellScript "sleep_prevent_toggle.sh" ''
-    STATE=$(pmset -g | awk '/SleepDisabled/ {print $2}')
-
-    if [ "$STATE" = "1" ]; then
-      sudo pmset -a disablesleep 0
-    else
-      sudo pmset -a disablesleep 1
-    fi
+  # Sleep-prevention enable click script: one-way, via `sudo pmset -a disablesleep 1`.
+  # Requires the NOPASSWD sudoers grant in nix-darwin/config/security.nix (scoped to
+  # exactly that invocation), since this click_script has no TTY to answer a
+  # password/Touch ID prompt. Idempotent -- clicking while already enabled is a no-op,
+  # so no double-click lock is needed. Disabling isn't exposed here; sleepPreventPlugin
+  # above still reflects whatever the real SleepDisabled state is if it's turned off
+  # some other way.
+  sleepPreventEnablePlugin = pkgs.writeShellScript "sleep_prevent_enable.sh" ''
+    sudo pmset -a disablesleep 1
 
     sketchybar --update
   '';
@@ -330,9 +325,9 @@ let
                       icon.color="$GREEN" \
                       label.drawing=off
 
-    # Sleep prevention toggle (sudo pmset -a disablesleep; update_freq=5 since it's a cheap
-    # `pmset -g` read, not a heavier poll like the 1s-interval items below). Icon-only (no label,
-    # matching power_icon) to keep the right-side item group narrow enough to clear the notch.
+    # Sleep prevention enable button (sudo pmset -a disablesleep 1; update_freq=5 since it's a
+    # cheap `pmset -g` read, not a heavier poll like the 1s-interval items below). Icon-only (no
+    # label, matching power_icon) to keep the right-side item group narrow enough to clear the notch.
     sketchybar --add item sleep_prevent right \
                 --set sleep_prevent \
                       icon=󰅶 \
@@ -341,7 +336,7 @@ let
                       label.drawing=off \
                       update_freq=5 \
                       script="${sleepPreventPlugin}" \
-                      click_script="${sleepPreventTogglePlugin}"
+                      click_script="${sleepPreventEnablePlugin}"
 
     # Tailscale-serve toggle for Mediator (127.0.0.1:43100). Icon-only, matching
     # sleep_prevent, in the same power_bracket group.

--- a/nix-darwin/config/security.nix
+++ b/nix-darwin/config/security.nix
@@ -4,16 +4,16 @@
   security.pam.services.sudo_local.touchIdAuth = true;
   security.pam.services.sudo_local.reattach = true;
 
-  # NOPASSWD, scoped to exactly these two invocations, so sketchybar's
-  # non-interactive click_script (no TTY, can't satisfy the Touch ID prompt
-  # above) can toggle system-wide sleep without a broader sudo grant.
+  # NOPASSWD, scoped to exactly this invocation, so sketchybar's non-interactive
+  # click_script (no TTY, can't satisfy the Touch ID prompt above) can enable
+  # system-wide sleep prevention without a broader sudo grant.
   #
   # Same rationale for the tailscale serve pair: sketchybar's toggle needs to
   # start/stop serving Mediator (127.0.0.1:43100) over the tailnet without a
   # TTY. Scoped to exactly these two invocations, not a `tailscale serve *`
   # wildcard, so the grant can't be reused to serve an arbitrary port.
   security.sudo.extraConfig = ''
-    ${username} ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 0, /usr/bin/pmset -a disablesleep 1, /run/current-system/sw/bin/tailscale serve --bg 43100, /run/current-system/sw/bin/tailscale serve --https=443 off
+    ${username} ALL=(root) NOPASSWD: /usr/bin/pmset -a disablesleep 1, /run/current-system/sw/bin/tailscale serve --bg 43100, /run/current-system/sw/bin/tailscale serve --https=443 off
   '';
 
   # One-shot migration cleanup: the sketchybar sleep_prevent toggle used to spawn a


### PR DESCRIPTION
## Summary
- Collapses the sketchybar `sleep_prevent` click_script from a bidirectional toggle (`sudo pmset -a disablesleep 0`/`1`, branching on a `SleepDisabled` read duplicated from the sibling display script) into an unconditional `sudo pmset -a disablesleep 1`.
- Narrows the matching NOPASSWD sudoers grant in `nix-darwin/config/security.nix` to just that one invocation, dropping the now-unused `disablesleep 0` grant.
- Renamed `sleepPreventTogglePlugin`/`sleep_prevent_toggle.sh` to `sleepPreventEnablePlugin`/`sleep_prevent_enable.sh` for naming consistency with the new one-way behavior (flagged in review).
- The display script (`sleepPreventPlugin`) is untouched — it still reads live `SleepDisabled` state, since the widget can still be disabled some other way outside this button.

## Test plan
- [x] `nix eval .#darwinConfigurations.M4-Max.config.security.sudo.extraConfig --raw | visudo -c -f -` — parsed OK, contains `disablesleep 1`, not `disablesleep 0`
- [x] `nix build --no-link '.#darwinConfigurations.M4-Max.system'` — exit 0
- [x] `nix flake check` — exit 0 (canonical CI gate: evaluates all darwinConfigurations/nixosConfigurations, builds treefmt)
- [x] Repo-wide grep confirms no other file references the removed `disablesleep 0` grant or the old toggle identifier