### PR TITLE
fix(ai-prompts): route review history to the store that actually holds it

### DIFF
--- a/home-manager/ai-tools/agent-skills/skills/serena-usage/SKILL.md
+++ b/home-manager/ai-tools/agent-skills/skills/serena-usage/SKILL.md
@@ -89,6 +89,25 @@ global/{topic}          shared across all projects — only when the user explic
                         a project-independent memory
 ```
 
+### Which store, before what to write
+
+Serena is not the only memory store, and choosing between them comes before choosing what to say. **Serena
+holds what is anchored to a symbol or a file position** — the code is what makes the entry true, so the entry
+is re-checkable by navigating to that code. **Claude auto-memory** — the per-project directory the harness
+injects, indexed by its `MEMORY.md` — holds what outlives the session that learned it and is anchored to
+nothing in the tree: review history and unresolved findings, a trap with the command that reproduces it, a
+policy the user stated, an option declined and why.
+
+The split is not cosmetic. An agent that reaches for review history in Serena finds an empty result and reads
+it as "no prior review", which is indistinguishable in the output from having checked and found none — so the
+next review starts from scratch and re-reports what was already raised. Getting the store wrong therefore
+fails silently and looks like a clean result.
+
+Write a fact to one store and link to it from the other. **A fact living in both drifts apart**, and the reader
+who finds the stale copy has no way to tell which one is current — the duplicate-hunting rules below apply
+across the two stores, not only within Serena, and the duplicate is hardest to see exactly when it spans them,
+because neither store's index lists the other's entries.
+
 ### What earns a memory
 
 Write for: a significant architectural pattern, a reusable debugging insight from a hard bug, a reusable
@@ -96,6 +115,9 @@ implementation pattern, a convention or preference the user stated, a transferab
 
 Do **not** write:
 
+- Anything the split above assigns to auto-memory — review history, a finding ledger, a trap, a user-stated
+  policy, a rejected option. Those belong there whatever their subject matter, and filing one here is the
+  silent failure named above rather than a tidy-up someone will notice.
 - A note that names one file and would not change what you do in a different file. That is a commit message.
 - Anything volatile enough to be wrong within weeks — line numbers, file counts, current status, an in-flight
   branch's state. **Volatility is the load-bearing exclusion**, because it rejects at write time exactly the

--- a/home-manager/ai-tools/ai-prompts/CLAUDE.md
+++ b/home-manager/ai-tools/ai-prompts/CLAUDE.md
@@ -163,11 +163,19 @@ stated, an architectural decision, a trap that cost you time, an option the user
 you rejected with the measurement that rejected it, or a verified absence with the query that established it.
 Do not defer this to the end of the task.
 
+Two stores hold these memories — auto-memory and Serena — and which one receives a fact is settled before the
+fact is written. serena-usage holds the boundary, the rule for a fact that already sits in both, and why
+choosing wrong fails silently rather than loudly.
+
 Do not write: what changed in one file this session (that is a commit message); a review's verdict or score; an
 intermediate observation from a verification still in progress, because it will outlive the run and contradict
 you; anything the repository already records. Never put an absolute path or a raw count in a memory body —
 store the command that reproduces the count, since the number is stale tomorrow and the path is wrong on the
 next machine.
+
+A ledger of unresolved findings — an identifier, a file:line, and a severity for each — records locations
+rather than judgement, so it is written despite the prohibition on verdicts above. What stays out is the score,
+the overall assessment, and the account of how the review went.
 
 Search existing memories by topic substring, not by exact name; a name-only duplicate check fails as soon as
 the naming scheme drifts, which is how one fact ends up in seven files.
@@ -195,7 +203,7 @@ govern costs its full body on every later request in the session.
 | A finding severe enough that being wrong about it is expensive | core-patterns, for the refutation pass |
 | Writing or evaluating tests | testing-patterns; test-integrity when a suite reports green |
 | Debugging, bisecting, or tracing a symptom to a cause | investigation-patterns |
-| Any Serena memory or symbol operation | serena-usage |
+| Writing or reading a memory in either store, or any Serena symbol operation | serena-usage |
 | Editing Common Lisp, Emacs Lisp, Scheme, Clojure, Fennel, or Janet source | paredit-cli |
 | Nix, flake, or Home Manager work | nix-ecosystem |
 | Needing a library's current API, version behavior, or migration notes | context7-usage |

--- a/home-manager/ai-tools/ai-prompts/agents/devops.md
+++ b/home-manager/ai-tools/ai-prompts/agents/devops.md
@@ -8,6 +8,12 @@ Design and review infrastructure-as-code, pipelines, and observability — with 
 a rollback path named for every change.
 </purpose>
 
+<skills_to_load>
+  Naming a skill here does not put it in context. Load it with the Skill tool when its trigger applies.
+  <load trigger="reading or writing a memory, in either store, before recording a pipeline pattern">serena-usage</load>
+  <load trigger="the change is Terraform or OpenTofu HCL, or recovers a failed apply">terraform-ecosystem</load>
+</skills_to_load>
+
 <rules priority="critical">
   <rule>Run the plan before the apply, and read the per-resource body rather than the summary counts. A plan
     summary is lossy in exactly the direction that hides destruction — "1 to change" is the same token whether

--- a/home-manager/ai-tools/ai-prompts/agents/performance.md
+++ b/home-manager/ai-tools/ai-prompts/agents/performance.md
@@ -8,6 +8,12 @@ Find where the time actually goes, change it, and prove the change with the same
 the baseline.
 </purpose>
 
+<skills_to_load>
+  Naming a skill here does not put it in context. Load it with the Skill tool when its trigger applies.
+  <load trigger="reading or writing a memory, in either store, before recording a rejected candidate">serena-usage</load>
+  <load trigger="a figure is about to be stated as a speedup, a regression, or a gate threshold">performance-benchmarking</load>
+</skills_to_load>
+
 <rules priority="critical">
   <rule>Measure before optimizing and measure again after. An improvement derived from a complexity argument is
     a prediction, not a result.</rule>

--- a/home-manager/ai-tools/ai-prompts/agents/quality-assurance.md
+++ b/home-manager/ai-tools/ai-prompts/agents/quality-assurance.md
@@ -73,7 +73,7 @@ to its cause — and say plainly what was read, what was run, and what was left 
     <step order="2">
       <action>Where the change touches a risky idiom, raise the concern and dispatch the security agent when
         confirmation is needed. Where a rendered surface is in scope, capture the accessibility tree.</action>
-      <tool>Grep, Task (security), Playwright browser_snapshot</tool>
+      <tool>Grep, Agent (security), Playwright browser_snapshot</tool>
       <output>Concerns with what raised each; accessibility tree, or why it could not be captured</output>
     </step>
   </phase>

--- a/home-manager/ai-tools/ai-prompts/agents/validator.md
+++ b/home-manager/ai-tools/ai-prompts/agents/validator.md
@@ -120,7 +120,7 @@ attempt to break that claim instead. Read-only: reports on outputs, never modifi
         findings with no file:line and no command output. Retry at most twice with a narrower prompt naming the
         specific files, or suggest an alternative agent. Document every attempt and outcome — never present an
         unanswered question as an absence of findings.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
       <output>Retry log with outcomes, or the reason retry was not attempted</output>
     </step>
   </phase>

--- a/home-manager/ai-tools/ai-prompts/commands/ask.md
+++ b/home-manager/ai-tools/ai-prompts/commands/ask.md
@@ -86,7 +86,7 @@ Answer a question about this project from evidence in it. Read-only: never modif
     <step order="1">
       <action>Execute the plan. Verify any external claim — library behavior, API contract, version support —
         against Context7 or the vendored source rather than recall.</action>
-      <tool>Task, Grep, Read, Context7</tool>
+      <tool>Agent, Grep, Read, Context7</tool>
       <output>Findings with file:line</output>
     </step>
   </phase>

--- a/home-manager/ai-tools/ai-prompts/commands/bug.md
+++ b/home-manager/ai-tools/ai-prompts/commands/bug.md
@@ -89,7 +89,7 @@ to do with; applies no fix.
         agent's work. Where the failure spans subsystems, dispatch in one message: quality-assurance for the
         failure mechanism and ranked hypotheses, explore for the error site and every recurrence, and
         general-purpose for the log timeline and dependency state. Name what you skipped and why.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
       <output>Findings with file:line, or the reason no agent was needed</output>
     </step>
     <step order="2">

--- a/home-manager/ai-tools/ai-prompts/commands/execute-full.md
+++ b/home-manager/ai-tools/ai-prompts/commands/execute-full.md
@@ -34,12 +34,16 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
       <tool>Skill (execution-workflow)</tool>
     </step>
     <step order="2">
-      <action>Activate the Serena project, call list_memories, and read the entries matching this task —
-        {feature}-patterns, {language}-conventions, testing-patterns, and any completion-checklist or
-        canonical-gate memory for this project. That last category tells you which commands constitute done
-        here, and what they deliberately leave uncovered, without re-deriving it from build files.</action>
-      <tool>Serena activate_project, list_memories, read_memory</tool>
-      <output>Matched memory names and the ones loaded</output>
+      <action>Read both memory stores, because memory_policy in CLAUDE.md splits them and this command needs
+        entries from each. From auto-memory, whose MEMORY.md indexes it: the traps this project has already
+        cost someone, and the issues a previous run of this command deferred instead of fixing — those are
+        this run's inherited work, not a clean slate. From Serena: {feature}-patterns,
+        {language}-conventions, testing-patterns, and any completion-checklist or canonical-gate memory for
+        this project. That last category tells you which commands constitute done here, and what they
+        deliberately leave uncovered, without re-deriving it from build files. Querying one store alone
+        returns an empty result that is indistinguishable from having checked and found nothing.</action>
+      <tool>Read (auto-memory MEMORY.md and the entries it names), Serena activate_project, list_memories, read_memory</tool>
+      <output>Matched memory names per store, the ones loaded, and the deferred issues inherited</output>
     </step>
   </phase>
 
@@ -67,7 +71,7 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
         the implementation, because the fix is moving code and its dependencies rather than rewriting it — and
         with one fix iteration available, discovering a layering violation in the review wave leaves no budget
         to correct it.</action>
-      <tool>Task (design)</tool>
+      <tool>Agent (design)</tool>
       <output>Placement approved, or the layer violation named before implementation</output>
     </step>
     <step order="4">
@@ -75,7 +79,7 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
         removes or migrates a definition, instruct the assignee to grep the identifier itself rather than the
         shape it is usually called in: forward declarations, differently-shaped call sites, comments, and test
         doubles share only the name.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
     </step>
     <step order="5">
       <action>Establish what the verification command covers before running it. Its name is not its scope: the
@@ -102,7 +106,7 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
       <action>Dispatch all six review agents in one message — quality-assurance, security, design, docs,
         performance, test. They evaluate independent dimensions of the same output, so serializing them only
         costs wall time.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
       <output>Six reports</output>
     </step>
   </phase>
@@ -132,7 +136,7 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
       <action>Prioritize the still-present issues critical before warning before info, delegate each to the
         agent matching its category, then verify each fix against the issue it addressed and re-run the
         verification commands.</action>
-      <tool>Task, Bash</tool>
+      <tool>Agent, Bash</tool>
       <output>Fixes with verification results</output>
     </step>
   </phase>
@@ -155,16 +159,36 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
     <on_unmet>Report the unaddressed issues as deferred, with reasons. Do not open a second fix iteration.</on_unmet>
   </reflection_checkpoint>
 
+  <phase name="verify">
+    <step order="1">
+      <action>Dispatch verification against the completion claim itself, after the fixes have landed and before
+        anything is reported done. This is not a seventh review dimension: collect_feedback asks whether the
+        work is good, and this asks whether the claim that it works survives an attempt to break it — boundary
+        values, interrupted operations, idempotency, the error paths the happy-path suite never entered. Give
+        it the enumerated commands said to exit zero and the claim each one supports, since an agent handed a
+        diff re-reviews the diff.</action>
+      <tool>Agent (verification)</tool>
+      <output>The claim attacked and what survived, or the input that broke it</output>
+    </step>
+  </phase>
+
   <phase name="persist">
     <step order="1">
-      <action>Against the memory_policy triggers in CLAUDE.md, capture what this cycle produced that is
+      <action>Write the issues the fix phase left unaddressed to auto-memory as a ledger, one entry per issue
+        carrying its identifier, file:line, severity, and the reason it was deferred. The fix_complete gate
+        demands they survive "in a form the next review can reconcile against", and with one fix iteration
+        there is no other mechanism — an unwritten deferral is rediscovered as a new finding or not at all.
+        Then, against the memory_policy triggers in CLAUDE.md, capture what this cycle produced that is
         expensive to re-derive and undiscoverable by grep: the project's canonical verification command with
         what it deliberately does not cover; the exact invocation that exited zero, including environment
         prefix and path flags; and any abstraction deliberately not built, paired with the condition that
         should re-open it — a deferral recorded without its trigger is re-argued next session with less
-        information than this one had. Then verify the memories read in prepare: bump, correct, or archive.</action>
-      <tool>Serena list_memories, write_memory or edit_memory, rename_memory</tool>
-      <output>Memories written, edited, or archived — or "persist: no triggers matched — skip"</output>
+        information than this one had. memory_policy decides which store each of these goes to; the ledger
+        and the traps are auto-memory's, the pattern anchored to a symbol is Serena's. Then verify the
+        memories read in prepare: bump, correct, or archive.</action>
+      <tool>Read and Write (auto-memory MEMORY.md and its entries), Serena list_memories, write_memory or edit_memory, rename_memory</tool>
+      <output>The ledger entries written, the memories written, edited, or archived — or "persist: no
+        triggers matched — skip", which requires the deferred-issue list to be empty as well</output>
     </step>
   </phase>
 </workflow>
@@ -205,8 +229,11 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
     <constraint>When removing or migrating a definition, grep the identifier itself across every file rather
       than the usage shape it typically appears in — the identifier is the only invariant shared by forward
       declarations, differently-shaped call sites, comments, and test doubles.</constraint></agent>
-  <agent name="memory" subagent_type="general-purpose">Decisions and patterns to Serena, and freshness of the
-    memories consulted this task.</agent>
+  <agent name="verification" subagent_type="verification">Attacks the completion claim after the fixes land,
+    rather than reviewing the diff a seventh time. Give it the commands claimed to exit zero and the claim each
+    supports, not the diff.</agent>
+  <agent name="memory" subagent_type="general-purpose">Decisions and patterns to whichever store memory_policy
+    assigns them, and freshness of the memories consulted this task.</agent>
   <agent name="validator" subagent_type="validator" dispatch="on_demand">Re-derive one disputed claim from its
     citation alone, without the originating agent's reasoning. Only when two agents disagree and their evidence
     does not settle it, or a consequential claim carries no citation.</agent>
@@ -231,7 +258,8 @@ confirmation between phases. Eliminating those hand-offs is what this command bu
     <pass_forward>The consolidated issues with the file:line each cites, the agent reports, and the test
       failures</pass_forward>
   </conditional_phase>
-  <sequential_step id="persist_phase" depends_on="fix">memory</sequential_step>
+  <sequential_step id="verify" depends_on="fix">verification, against the settled post-fix artifact</sequential_step>
+  <sequential_step id="persist_phase" depends_on="verify">memory</sequential_step>
 </execution_graph>
 
 <decision_criteria>

--- a/home-manager/ai-tools/ai-prompts/commands/execute.md
+++ b/home-manager/ai-tools/ai-prompts/commands/execute.md
@@ -101,7 +101,7 @@ quality review across every dimension, use /execute-full.
     <step order="2">
       <action>Dispatch each task with its scope, target paths, expected deliverable, the command that verifies
         it, and any reference implementation to follow.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
     </step>
   </phase>
   <reflection_checkpoint id="assignment_complete" after="assign">
@@ -146,7 +146,7 @@ quality review across every dimension, use /execute-full.
     <step order="4">
       <action>If tests fail, delegate one targeted fix for the specific failing tests and re-run once. If
         failures remain, report them as blockers and set the status to error.</action>
-      <tool>Task (test agent, or general-purpose)</tool>
+      <tool>Agent (test agent, or general-purpose)</tool>
     </step>
     <step order="5">
       <action>Before reporting that something could not be verified in this environment, grep the environment
@@ -154,6 +154,15 @@ quality review across every dimension, use /execute-full.
         adapter, or a recorded-fixture mode. A codebase mature enough to have a test suite usually has a
         runnable driver behind that seam, and an unverifiable claim reported as a gap is rarely revisited.</action>
       <output>The substitute mode found and exercised, or confirmation none exists</output>
+    </step>
+    <step order="6">
+      <action>Once the suite is green, dispatch verification against the claim that the change works. A green
+        suite is the evidence most often offered and least often attacked: it reports that the paths someone
+        thought to write still behave, which is a different claim from the one being made. Hand over the
+        commands that exited zero and the claim each supports rather than the diff — an agent handed a diff
+        reviews the diff, which the review agents have already done.</action>
+      <tool>Agent (verification)</tool>
+      <output>What survived the attack and what broke</output>
     </step>
   </phase>
 
@@ -197,8 +206,12 @@ quality review across every dimension, use /execute-full.
     stale references left.</agent>
   <agent name="review" subagent_type="quality-assurance">Holistic post-implementation review across the agent
     reports and test results; go/no-go with rationale.</agent>
+  <agent name="verification" subagent_type="verification">Attacks the claim that the change works, once the
+    suite is green: boundary values, interrupted operations, idempotency, the error paths a passing suite never
+    entered. Give it the commands claimed to exit zero and the claim each supports, not the diff — an agent
+    handed a diff reviews the diff, which the review agents have already done.</agent>
   <agent name="memory" subagent_type="general-purpose">Patterns and decisions surfaced by the implementation
-    agents, written to Serena.</agent>
+    agents, written to whichever store memory_policy assigns them.</agent>
   <agent name="validator" subagent_type="validator" dispatch="on_demand">Re-derive one disputed claim from its
     citation alone, without the originating agent's reasoning. Dispatch only when two agents disagree and their
     evidence does not settle it, or a consequential claim rests on no citation.</agent>
@@ -211,7 +224,8 @@ quality review across every dimension, use /execute-full.
   <parallel_group id="quality_assurance" depends_on="none">quality, security</parallel_group>
   <parallel_group id="implementation" depends_on="none">test, docs</parallel_group>
   <sequential_step id="review_phase" depends_on="quality_assurance,implementation">review</sequential_step>
-  <sequential_step id="persist_phase" depends_on="review_phase">memory</sequential_step>
+  <sequential_step id="claim_attack" depends_on="review_phase">verification, against the settled artifact</sequential_step>
+  <sequential_step id="persist_phase" depends_on="claim_attack">memory</sequential_step>
 </execution_graph>
 
 <decision_criteria>

--- a/home-manager/ai-tools/ai-prompts/commands/feedback.md
+++ b/home-manager/ai-tools/ai-prompts/commands/feedback.md
@@ -9,8 +9,9 @@ specialists in parallel, refute the critical findings, and report what to do abo
 </purpose>
 
 <rules priority="critical">
-  <rule>Every agent this command dispatches is read-only. It reviews work; it does not change it.</rule>
-  <rule>Launch all Task calls of one dispatch wave in a single message. A wave is the selected mode's
+  <rule>Every agent this command dispatches is read-only. It reviews work; it does not change it. Writing this
+    review's own memory entries is not a change to the work under review, so the persist phase proceeds.</rule>
+  <rule>Launch all Agent calls of one dispatch wave in a single message. A wave is the selected mode's
     specialists, or the refute phase's per-finding validator dispatches. The refute wave running after the
     specialist wave is sequencing, not the prohibited pattern.</rule>
   <rule>A finding is complete only when it carries four things: the defect's file:line; the existing test that
@@ -22,7 +23,9 @@ specialists in parallel, refute the critical findings, and report what to do abo
 </rules>
 <rules priority="important">
   <rule>Review the work this session did, targeting session operations rather than the git diff — the diff
-    includes work this session did not do.</rule>
+    includes work this session did not do. That bars the diff's contents as the thing reviewed, not the commit
+    as a way to learn which files to open: where this session holds no Edit or Write history, take the file
+    list from the commit pinned in prepare and review those files directly.</rule>
   <rule>Severity is calibrated by runtime impact, not style preference: critical is data loss or security,
     warning is degraded behavior, info is style.</rule>
   <rule>State a quantitative claim as a direction unless it was measured on both sides — whichever agent
@@ -40,16 +43,21 @@ specialists in parallel, refute the critical findings, and report what to do abo
       <output>Skills loaded</output>
     </step>
     <step order="2">
-      <action>Activate the Serena project, call list_memories, and read the entries matching this review —
-        {project}-conventions, code-quality-*, architecture-*, and any stored review of this component.</action>
-      <tool>Serena activate_project, list_memories, read_memory</tool>
-      <output>Matched memory names and the ones loaded</output>
+      <action>Read the review history from auto-memory first: its MEMORY.md index names every entry, and the
+        ledger this command's persist phase writes lives there. Then read the Serena entries matching this
+        review — {project}-conventions, code-quality-*, architecture-* — for the conventions anchored to a
+        symbol or a file position. The two stores are not interchangeable, and memory_policy in CLAUDE.md says
+        which one holds what.</action>
+      <tool>Read (auto-memory MEMORY.md and the entries it names), Serena activate_project, list_memories, read_memory</tool>
+      <output>Matched memory names per store, and the ones loaded</output>
     </step>
     <step order="3">
-      <action>Retrieve the previous review's findings, from the stored review memories or earlier in the
-        session, with each identifier and location. This command otherwise re-diagnoses from scratch every
-        time, so an unfixed finding is either rediscovered as new or missed entirely — and an item raised twice
-        and still standing is a decision the user needs to make, not a line to repeat.</action>
+      <action>Retrieve the previous review's findings from the auto-memory ledger this command's persist phase
+        writes, or from earlier in the session, with each identifier and location. This command otherwise
+        re-diagnoses from scratch every time, so an unfixed finding is either rediscovered as new or missed
+        entirely — and an item raised twice and still standing is a decision the user needs to make, not a line
+        to repeat. Looking for that ledger in Serena returns nothing, which is the wrong store rather than an
+        absence of prior reviews.</action>
       <output>Prior findings with identifiers and locations, or "no prior review found"</output>
     </step>
     <step order="4">
@@ -63,9 +71,12 @@ specialists in parallel, refute the critical findings, and report what to do abo
   <phase name="select">
     <step order="1">
       <action>Identify the previous command and select its mode from the modes table. Establish the files in
-        scope as explicit paths, not "the recent changes".</action>
-      <tool>Serena find_symbol, get_symbols_overview</tool>
-      <output>Mode, the command that selected it, and the file list</output>
+        scope as explicit paths, not "the recent changes". Where this session carries no Edit or Write history
+        — the command was invoked fresh, which the previous-command argument anticipates — take the paths from
+        the commit pinned in prepare with git show --stat, and report that scope came from the commit rather
+        than from session operations, so a reader knows which one the findings describe.</action>
+      <tool>Serena find_symbol, get_symbols_overview, Bash: git show --stat</tool>
+      <output>Mode, the command that selected it, the file list, and the source the list came from</output>
     </step>
   </phase>
   <reflection_checkpoint id="analysis_quality" after="select">
@@ -80,7 +91,7 @@ specialists in parallel, refute the critical findings, and report what to do abo
     <step order="1">
       <action>Dispatch the selected mode's agents in one message, each carrying the four-part finding
         requirement from the critical rules.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
       <output>One report per agent, or a named agent that returned nothing</output>
     </step>
     <step order="2">
@@ -129,7 +140,7 @@ specialists in parallel, refute the critical findings, and report what to do abo
         refuter is asked to find the flaw. Validator's own default framing expects several reports to compare,
         so state in the prompt that this is a single-claim independent-verification task and that it should
         disregard its usual single-source-means-unvalidated framing and re-derive whether the finding holds.</action>
-      <tool>Task (validator)</tool>
+      <tool>Agent (validator)</tool>
       <output>One refutation attempt per critical finding</output>
     </step>
     <step order="3">
@@ -152,12 +163,17 @@ specialists in parallel, refute the critical findings, and report what to do abo
 
   <phase name="persist">
     <step order="1">
-      <action>Against the memory_policy triggers in CLAUDE.md, record a recurring quality issue, a reusable
-        review pattern, or a project convention as a rule the next session can apply, pinned to the revision it
-        was found in. Search list_memories by topic substring first. Output "persist: no triggers matched —
-        skip" when none apply.</action>
-      <tool>Serena list_memories, write_memory or edit_memory</tool>
-      <output>Memory name written or edited, or the explicit skip</output>
+      <action>Write the ledger of findings still unresolved at the end of this run to auto-memory, one entry per
+        finding carrying its identifier, file:line, and severity. That ledger is what prepare step 3 reads next
+        time, so a run that skips it leaves the next review to start from nothing — memory_policy in CLAUDE.md
+        states why a ledger of locations is not the review verdict it also forbids. Alongside it, and against
+        the same memory_policy triggers, record a recurring quality issue, a reusable review pattern, or a
+        project convention as a rule the next session can apply, pinned to the revision it was found in. Search
+        the auto-memory index and Serena's list_memories by topic substring before writing either, so an
+        existing entry is edited rather than duplicated. Output "persist: no triggers matched — skip" only when
+        the ledger is empty as well.</action>
+      <tool>Read and Write (auto-memory MEMORY.md and its entries), Serena list_memories, write_memory or edit_memory</tool>
+      <output>The ledger entries written, the memory names written or edited, or the explicit skip</output>
     </step>
   </phase>
 </workflow>
@@ -171,7 +187,11 @@ specialists in parallel, refute the critical findings, and report what to do abo
 
 <modes>
   Selected from the previous command. Every mode dispatches its agents in one message, and loads fact-check
-  where the work under review makes external claims.
+  where the work under review makes external claims. Loading it injects the method without running it, so name
+  the agent that applies it in that mode's dispatch — docs where the claims are about a documented interface,
+  quality-assurance otherwise — and have that agent check each external claim against Context7 or the vendored
+  source. Without that assignment the fact_check_results section has no step that produces it and comes back
+  empty from a review that did read external claims.
 
   <mode name="define" after="/define" target="the execution plan from the session">
     Step granularity, dependencies, risk identification, completeness, feasibility.

--- a/home-manager/ai-tools/ai-prompts/commands/upstream.md
+++ b/home-manager/ai-tools/ai-prompts/commands/upstream.md
@@ -65,7 +65,7 @@ breakdown that /execute can consume. Everything produced is a handoff the user d
     <objective>Collect the evidence, in parallel</objective>
     <step order="1">
       <action>Dispatch guidelines, pr_template, changes, tests, and pr_samples in one message.</action>
-      <tool>Task</tool>
+      <tool>Agent</tool>
       <output>Five reports</output>
     </step>
   </phase>


### PR DESCRIPTION
## 直すもの

`/feedback` は memory を Serena だけで読み書きしていたが、findings を次回へ繰り越すために必要なレビュー履歴は Claude auto-memory 側にある。`prepare` が「前回の findings 台帳」を要求する一方、`persist` にはそれを書くカテゴリが無く、毎回ゼロから再診断していた。コマンド本文自身が `This command otherwise re-diagnoses from scratch every time` とその帰結を書いている。

`execute-full.md` も同型。`fix_complete` ゲートが未対応 issue を `in a form the next review can reconcile against` で残せと要求し、`one fix iteration leaves no other mechanism for tracking it` と明記しているのに、`persist` はそれを一切書いていなかった。

## 変更

| ファイル | 内容 |
|---|---|
| `CLAUDE.md` | 2ストアを名指し、選択の判断は serena-usage へ委譲。位置情報の台帳は禁止されている「レビューの判定」に当たらないと明記。auto-memory にしか書かない agent にも届くよう `load_table` のトリガーを拡張 |
| `serena-usage/SKILL.md` | 所有権ドクトリンの正本。ストアを誤ると静かに失敗する理由を含む |
| `commands/feedback.md` | 台帳を auto-memory で読み書き。セッションに Edit 履歴が無い場合は pin した commit からファイル一覧を取る。fact-check を適用する agent を名指し（skill のロードは実行ではない） |
| `commands/execute-full.md` | 同じストア修正に加え、fix フェーズが繰り越した issue を台帳として書く |
| `commands/execute.md`, `execute-full.md` | `verification` agent を dispatch。3ランタイム全てに登録済みだが、どのコマンドからも到達できなかった |
| `agents/performance.md`, `devops.md` | `serena-usage` をロード。両者とも memory を読み書きするのにトリガーが無く、新しい書き分けが届かない |
| 13箇所 | dispatch ツール名を `Task` から実在する `Agent` へ |

## 検証

- `nix build .#darwinConfigurations.M4-Max.system` — exit 0
- 生成バイトを3ランタイム分確認（claude-code / codex / opencode）。変更が載っており、旧テキストの残留なし
- pre-commit の gitleaks — no leaks found

**`nix flake check` はこの変更に対して空虚**。treefmt に markdown formatter が無く（actionlint / nixfmt / taplo / yamlfmt / fish_indent / stylua / shfmt）、`darwinConfigurations` は toplevel を forcing しない。緑を被覆と読まないこと。`.github/workflows/` にもプロンプト検証は存在しない。

## 未検証

`/feedback` を実際に走らせていない。繰り越しループが閉じることは各フェーズを端から端まで読んで確認したもので、実行による確認ではない。

## 意図的に含めていないもの

- `commands/execute.md:47` と `:179` は依然 Serena のみのルーティング。同じ種類だが軽く、繰り越しの要求文が無いためルーティングだけの問題。
- 既存 Serena エントリと auto-memory の突き合わせ。プロジェクトごとの作業でこのリポジトリの外。
- 並列 dispatch の規律（独立サブタスクを1メッセージで送る）が実運用でほぼ発火していないことを transcript 全体の測定で確認したが、原因が未特定のため本 PR では触っていない。ツール名ドリフトは原因として反証済み。
