### PR TITLE
docs(ai-prompts): bar restating diff/history/CI content in commit messages and PR bodies

### DIFF
--- a/home-manager/ai-tools/ai-prompts/commands/execute-full.md
+++ b/home-manager/ai-tools/ai-prompts/commands/execute-full.md
@@ -25,6 +25,13 @@ Execute, review across every quality dimension, then fix what the review found �
     exact shape of a completion claim that names no command and no file:line. It applies hardest to the fix
     phase, where a fixed symptom described in praise rather than as a named diff hunk is indistinguishable from
     a symptom that stopped reproducing on its own.</rule>
+  <rule>A commit message or PR body holds only what its reader needs to approve and cannot get anywhere else.
+    Not the diff — it already shows every changed file, line, and function name. Not the commit history — it
+    already shows how the work evolved. Not a CI check that already ran — the checks tab already shows its
+    pass/fail and count. Write instead the judgment the diff can't show: why a workaround stands in for a root
+    fix, what was deliberately left out of scope, and which verification no CI gate runs and had to be done by
+    hand — name what was actually checked, not that it passed, since a selector matching nothing exits zero the
+    same as a real one.</rule>
 </rules>
 <rules priority="important">
   <rule>Skip the fix phase when the review found nothing — say so explicitly instead of running it as a

--- a/home-manager/ai-tools/ai-prompts/commands/execute.md
+++ b/home-manager/ai-tools/ai-prompts/commands/execute.md
@@ -24,6 +24,13 @@ Executes a task by delegating detail to sub-agents while holding policy and orch
     correctness rule, not a style preference: padding is what makes an unverified claim read as a finished one,
     and "successfully implemented a robust solution" is the exact shape of a completion claim that names no
     command and no file:line.</rule>
+  <rule>A commit message or PR body holds only what its reader needs to approve and cannot get anywhere else.
+    Not the diff — it already shows every changed file, line, and function name. Not the commit history — it
+    already shows how the work evolved. Not a CI check that already ran — the checks tab already shows its
+    pass/fail and count. Write instead the judgment the diff can't show: why a workaround stands in for a root
+    fix, what was deliberately left out of scope, and which verification no CI gate runs and had to be done by
+    hand — name what was actually checked, not that it passed, since a selector matching nothing exits zero the
+    same as a real one.</rule>
 </rules>
 <rules priority="important">
   <rule>Delegate detail: run independent units in parallel, dependent ones in order, and verify output before


### PR DESCRIPTION
## Why

/execute and /execute-full's "no AI-slop prose" rule bans hollow *language* in commit messages and PR bodies, but nothing barred true, well-written sentences that just restate content the reviewer can already get elsewhere — the diff's file list, the commit history, or a CI check that already ran.

Ported from the reasoning in [attmcojp/arrove-seria#2814](https://github.com/attmcojp/arrove-seria/pull/2814): a PR body should hold only what a reviewer needs to approve *and* can't get anywhere else.

## What

Added one critical rule to each of `execute.md` and `execute-full.md` (the only two prompts here that write commit messages or PR bodies): write the judgment call the diff can't show — why a workaround stands in for a root fix, what was deliberately scoped out, what verification no CI gate covers — instead of restating what's already visible elsewhere.