### PR TITLE
feat(ai-prompts): add claude-design MCP server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,6 +198,55 @@
 
       perSystem =
         { pkgs, ... }:
+        let
+          sharedAiTools = import ./home-manager/ai-tools/shared { inherit (pkgs) lib; };
+
+          # lib.debug.runTests returns [] when every case passes, else the failing cases.
+          sharedAiToolsTestFailures = pkgs.lib.debug.runTests {
+            testMcpServerToOpencodeHttp = {
+              expr = sharedAiTools.mcpServerToOpencode {
+                type = "http";
+                url = "https://example.com/mcp";
+              };
+              expected = {
+                type = "http";
+                url = "https://example.com/mcp";
+              };
+            };
+            testMcpServerToOpencodeLocalNoArgs = {
+              expr = sharedAiTools.mcpServerToOpencode { command = "/bin/foo"; };
+              expected = {
+                type = "local";
+                command = [ "/bin/foo" ];
+              };
+            };
+            testMcpServerToOpencodeLocalWithArgs = {
+              expr = sharedAiTools.mcpServerToOpencode {
+                command = "/bin/foo";
+                args = [
+                  "a"
+                  "b"
+                ];
+              };
+              expected = {
+                type = "local";
+                command = [
+                  "/bin/foo"
+                  "a"
+                  "b"
+                ];
+              };
+            };
+            testBashDenyPatternToOpencodeStripsTerminatorSuffix = {
+              expr = sharedAiTools.bashDenyPatternToOpencode "sudo rm -:*";
+              expected = "sudo rm -*";
+            };
+            testBashDenyPatternToOpencodeLeavesOtherPatternsUnchanged = {
+              expr = sharedAiTools.bashDenyPatternToOpencode "rm -rf /*";
+              expected = "rm -rf /*";
+            };
+          };
+        in
         {
           treefmt.projectRootFile = "flake.nix";
           treefmt.programs.actionlint.enable = true;
@@ -207,6 +256,20 @@
           treefmt.programs.fish_indent.enable = true;
           treefmt.programs.stylua.enable = true;
           treefmt.programs.shfmt.enable = true;
+
+          checks.shared-ai-tools-lib =
+            pkgs.runCommand "shared-ai-tools-lib-tests"
+              {
+                failuresJson = builtins.toJSON sharedAiToolsTestFailures;
+              }
+              ''
+                if [ "$failuresJson" != "[]" ]; then
+                  echo "home-manager/ai-tools/shared regression tests failed:" >&2
+                  echo "$failuresJson" >&2
+                  exit 1
+                fi
+                touch $out
+              '';
 
           devShells.default = pkgs.mkShell {
             packages = with pkgs; [ nixd ];

--- a/home-manager/ai-tools/shared/default.nix
+++ b/home-manager/ai-tools/shared/default.nix
@@ -17,6 +17,14 @@ rec {
         type = "http";
         url = "https://mcp.deepwiki.com/mcp";
       };
+      # Auth is the Claude-Code-only /design-login and /design-sync slash commands, not the generic
+      # remote-MCP OAuth flow deepwiki/Slite/ClickUp use, so this entry is inert in opencode and Codex
+      # even though it's registered there too. Do not copy this entry's shared placement as precedent
+      # for a server that isn't similarly Claude-Code-gated.
+      "claude-design" = {
+        type = "http";
+        url = "https://api.anthropic.com/v1/design/mcp";
+      };
     };
 
   mcpServerToOpencode =


### PR DESCRIPTION
## Summary
- Registers Anthropic's Claude Design MCP server (`https://api.anthropic.com/v1/design/mcp`, HTTP transport) in `shared.mcpServers`, propagating to Claude Code, opencode, and Codex through the existing shared-catalog merge, same mechanism `deepwiki` already uses.
- Adds a comment marking the entry as functionally Claude-Code-only: auth is via the Claude-Code-specific `/design-login` and `/design-sync` slash commands, not the generic remote-MCP OAuth flow the other HTTP entries use, so it's inert in opencode/Codex by design, not by accident.
- Adds `checks.<system>.shared-ai-tools-lib` to `flake.nix`, a regression test for `mcpServerToOpencode` and `bashDenyPatternToOpencode` (both previously uncovered by any committed gate), wired into `nix flake check`.

## Design notes for the reviewer
- Shared placement (vs. scoping this to Claude Code only) was a deliberate choice: opencode and Codex will list this MCP server too, even though they can't authenticate against it, in preference to building new per-CLI scoping infrastructure that doesn't otherwise exist in this repo.
- The flake check was added during review, not requested up front — flagged and confirmed before being kept, since it touches `flake.nix`, a config file. It was proven to fail against a deliberately broken version of the code under test and pass against the real code.
- Whether opencode/Codex fail soft or loud when they attempt to connect to this entry unauthenticated is unverified (external runtime behavior of those two tools, not observable from this repo).

## Test plan
- [x] `nix flake check` — exit 0, both `treefmt` and the new `shared-ai-tools-lib` check ran and passed.
- [x] `nix build .#darwinConfigurations.M4-Max.system --dry-run` — exit 0, full module evaluation succeeded across all three MCP-consumer configs.
- [x] Independent verification pass: built and inspected the actual rendered artifacts (`programs.claude-code.mcpServers`, the real `opencode.json`, the codex wrapper's `-c mcp_servers.claude-design=...` flag) rather than trusting eval success alone.
- [x] Independent verification pass: reproduced the new flake check's red→green cycle in an isolated `/tmp` copy, confirming it fails for the stated reason and passes with a matching store hash.
- [ ] Not run: an actual `/design-login` + live connection to the Claude Design MCP endpoint — requires a real subscription and interactive login, out of scope for this environment.