### PR TITLE
feat(emacs): make the scratchpad hotkey re-open near-instant

### DIFF
--- a/home-manager/editor/advanced.nix
+++ b/home-manager/editor/advanced.nix
@@ -3,6 +3,7 @@
   imports = [
     ./emacs
     ./emacs-service
+    ./emacs-scratchpad
     ./copilot-language-server
   ];
 

--- a/home-manager/editor/emacs-scratchpad/default.nix
+++ b/home-manager/editor/emacs-scratchpad/default.nix
@@ -1,0 +1,23 @@
+{ pkgs, emacsLib, ... }:
+let
+  lib = pkgs.lib;
+in
+{
+  launchd.agents.emacs-scratchpad-kitty = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    domain = "gui";
+    config = {
+      ProgramArguments = [
+        "/bin/sh"
+        "-c"
+        "/bin/wait4path /nix/store && exec ${emacsLib.scratchpadKittyServer}"
+      ];
+      # Not KeepAlive: when a hotkey-spawned kitty already owns the instance
+      # group, this process acts as a client and exits, which KeepAlive would
+      # turn into a relaunch loop.
+      RunAtLoad = true;
+      KeepAlive = false;
+      ProcessType = "Interactive";
+    };
+  };
+}

--- a/home-manager/editor/emacs/elisp/init.org
+++ b/home-manager/editor/emacs/elisp/init.org
@@ -1762,9 +1762,22 @@ Handles focus reporting (DECSET 1004) and bracketed paste (DECSET 2004)."
   (defun my/scratchpad-init ()
     "Initialize scratchpad: switch to *scratch* and enable nskk-mode."
     (switch-to-buffer "*scratch*")
-    (when (fboundp 'nskk-mode)
+    (when (and (fboundp 'nskk-mode)
+               (not (bound-and-true-p nskk-mode)))
       (nskk-mode 1))
     nil)
+
+  (defun my/scratchpad-warm-up ()
+    "Enable nskk-mode in *scratch* before the first scratchpad hotkey needs it."
+    (when (fboundp 'nskk-mode)
+      (with-current-buffer (get-buffer-create "*scratch*")
+        (unless (bound-and-true-p nskk-mode)
+          (condition-case err
+              (nskk-mode 1)
+            (error (message "scratchpad warm-up skipped: %s"
+                            (error-message-string err))))))))
+
+  (run-with-idle-timer 3 nil #'my/scratchpad-warm-up)
 #+end_src
 * Coding
 :PROPERTIES:

--- a/home-manager/editor/lib/emacs-constants.nix
+++ b/home-manager/editor/lib/emacs-constants.nix
@@ -7,4 +7,6 @@
   defaultWindowHeight = 600;
 
   defaultAppId = "FloatingEmacs";
+
+  scratchpadInstanceGroup = "emacs-scratchpad";
 }

--- a/home-manager/editor/lib/emacs.nix
+++ b/home-manager/editor/lib/emacs.nix
@@ -8,9 +8,24 @@ let
     defaultWindowWidth
     defaultWindowHeight
     defaultAppId
+    scratchpadInstanceGroup
     ;
   socketPath =
     if pkgs.stdenv.isDarwin then constants.socketPath else "/run/user/$(id -u)/emacs/server";
+
+  # Holds the single-instance socket open with no window so the hotkey pays
+  # only a window create, not a kitty cold start. Close confirmation is a
+  # process-wide setting, so it must be disabled here rather than per window.
+  scratchpadKittyServer = pkgs.writeShellScript "emacs-scratchpad-kitty-server" ''
+    exec ${pkgs.kitty}/bin/kitty \
+      --single-instance \
+      --instance-group ${scratchpadInstanceGroup} \
+      --start-as=hidden \
+      -o confirm_os_window_close=0 \
+      -o macos_quit_when_last_window_closed=no \
+      -o remember_window_size=no \
+      -- ${pkgs.coreutils}/bin/true
+  '';
 
   mkScratchpadToggle =
     {
@@ -118,14 +133,14 @@ let
 
         focus_existing_window() {
           local i=0
-          while [ "$i" -lt 100 ]; do
+          while [ "$i" -lt 500 ]; do
             TARGET_ID="$(window_id_by_title)"
             if [ -n "$TARGET_ID" ]; then
               "$AEROSPACE" focus --window-id "$TARGET_ID"
               return 0
             fi
             i=$((i + 1))
-            sleep 0.1
+            sleep 0.02
           done
 
           return 1
@@ -165,12 +180,16 @@ let
 
         # Keep hotkey startup on AeroSpace/kitty/emacsclient only. AppleScript/System Events
         # adds a fixed delay and can race with Accessibility permissions during login.
+        # The instance group is normally served by the resident kitty that scratchpadKittyServer
+        # (started by home-manager/editor/emacs-scratchpad at login) holds open; when it is
+        # absent this invocation becomes the server and must not quit on close.
         "$KITTY" \
-          --single-instance=no \
+          --single-instance \
+          --instance-group ${scratchpadInstanceGroup} \
           -o close_on_child_death=yes \
-          -o macos_quit_when_last_window_closed=yes \
+          -o confirm_os_window_close=0 \
+          -o macos_quit_when_last_window_closed=no \
           -o term=xterm-256color \
-          -o focus_reporting_protocol=none \
           -o remember_window_size=no \
           -o initial_window_width=${toString windowWidth} \
           -o initial_window_height=${toString windowHeight} \
@@ -225,14 +244,14 @@ let
 
         center_new_window() {
           local i=0
-          while [ "$i" -lt 100 ]; do
+          while [ "$i" -lt 500 ]; do
             window_data_value="$(window_data)"
             if [ -n "$window_data_value" ]; then
               ${pkgs.niri}/bin/niri msg action center-window
               return 0
             fi
             i=$((i + 1))
-            sleep 0.1
+            sleep 0.02
           done
 
           return 1
@@ -249,7 +268,7 @@ let
           window_data_value="$(window_data)"
           if [ -z "$window_data_value" ]; then
             start_emacs_service
-            XMODIFIERS=@im= ${kitty} --class "$APP_ID" -o initial_window_width=80c -o initial_window_height=24c -e ${emacsclientTerminal} &
+            XMODIFIERS=@im= ${kitty} --single-instance --instance-group ${scratchpadInstanceGroup} --class "$APP_ID" -o confirm_os_window_close=0 -o initial_window_width=80c -o initial_window_height=24c -e ${emacsclientTerminal} &
             center_new_window
           fi
         fi
@@ -272,6 +291,7 @@ in
   inherit
     socketPath
     mkScratchpadToggle
+    scratchpadKittyServer
     defaultWindowWidth
     defaultWindowHeight
     ;

--- a/home-manager/shell/kitty/default.nix
+++ b/home-manager/shell/kitty/default.nix
@@ -1,3 +1,7 @@
+{ pkgs, ... }:
+let
+  emojiFont = if pkgs.stdenv.isDarwin then "Apple Color Emoji" else "Noto Color Emoji";
+in
 {
   programs.kitty.enable = true;
   programs.kitty.themeFile = "Dracula";
@@ -6,8 +10,8 @@
   programs.kitty.font.size = 13;
 
   # HackGen Console NF has no emoji glyphs; route emoji/pictograph/flag
-  # ranges to Noto Color Emoji instead of falling back to a tofu glyph.
-  programs.kitty.settings.symbol_map = "U+1F300-U+1FAFF,U+2600-U+27BF,U+1F1E6-U+1F1FF Noto Color Emoji";
+  # ranges to the platform's color emoji font instead of a tofu glyph.
+  programs.kitty.settings.symbol_map = "U+1F300-U+1FAFF,U+2600-U+27BF,U+1F1E6-U+1F1FF ${emojiFont}";
 
   programs.kitty.settings = {
     remember_window_size = false;
@@ -37,9 +41,6 @@
 
     enable_audio_bell = false;
     visual_bell_duration = 0;
-
-    # Focus reporting (disable to prevent OI escape sequences in terminal apps)
-    focus_reporting_protocol = "none";
 
     # Splits/Windows (not covered by Dracula theme)
     active_border_color = "#f8f8f2";


### PR DESCRIPTION
## Why

Mod+I / alt-i took about 5 s to show an editable scratchpad. About 4 s was `(nskk-mode 1)` inside `my/scratchpad-init` (fixed in nskk.el, takeokunn/nskk.el `perf/instant-style-load`), and 0.63 s was a kitty cold start on every open because the toggle spawned a fresh process with `--single-instance=no`.

## What

- `init.org`: `my/scratchpad-init` no longer re-enables `nskk-mode` when `*scratch*` already has it, and an idle timer enables it ahead of the first hotkey.
- `emacs.nix`: kitty opens through `--single-instance --instance-group emacs-scratchpad`; `scratchpadKittyServer` holds that group open with no window so a re-open is a window create instead of a process start. The window poll runs every 20 ms (same 10 s budget). `confirm_os_window_close=0` is set on the server because it is process-wide.
- New `home-manager/editor/emacs-scratchpad`: launchd agent that starts the resident kitty at login (macOS only). It is `RunAtLoad` without `KeepAlive`: when a hotkey-spawned kitty already owns the group the agent acts as a client and exits, which `KeepAlive` would turn into a relaunch loop.
- `shell/kitty/default.nix`: drop `focus_reporting_protocol` (unknown to kitty 0.48, was logging a warning) and use `Apple Color Emoji` on macOS where `Noto Color Emoji` is not installed.

## Measurements (M4-Max, AeroSpace)

| path | before | after |
|---|---|---|
| kitty window via existing instance group | 0.63 s cold start | 0.009–0.025 s |
| close then re-open through the toggle script | about 5 s | 0.19–0.26 s |
| focus toggle of an existing window | 0.06 s | 0.06 s |

The nskk part of the latency disappears once nur-packages picks up the nskk.el change and the Emacs daemon restarts.

## Verification

- `nix build .#darwinConfigurations.M4-Max.system`: exit 0.
- `nix eval .#nixosConfigurations.X13Gen2.config.system.build.toplevel.drvPath`: exit 0 (niri path evaluates; the resident server is macOS only, Linux keeps the previous cold-start behaviour after a close).
- `nix flake check`: exit 0.
- Generated toggle, emacsclient wrapper, and server scripts pass `bash -n`; five live open/close cycles left no terminal frame behind.
