### PR TITLE
chore(homebrew): drop unused element/postman casks and orca tap

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -8,9 +8,6 @@
     "pdfpc"
     "docker-credential-helper"
   ];
-  homebrew.taps = [
-    "stablyai/orca"
-  ];
   homebrew.casks = [
     "amical"
     "aquaskk"
@@ -19,19 +16,16 @@
     "clickup"
     "drawio"
     "docker-desktop"
-    "element"
     "font-sketchybar-app-font"
     "google-chrome"
     "microsoft-excel"
     "keycastr"
     "postico"
-    "postman"
     "raycast"
     "sequel-ace"
     "sf-symbols"
     "slack"
     "slite"
-    "stablyai/orca/orca"
     "sublime-text"
   ];
 }


### PR DESCRIPTION
## Summary
- Removes the `element`, `postman` casks and the `stablyai/orca` tap/cask from `nix-darwin/config/homebrew.nix`.

## Test plan
- [ ] `nix build .#darwinConfigurations.<host>.system` (or `darwin-rebuild check`) evaluates cleanly on the affected host.