### PR TITLE
fix(kitty): route more emoji-flagged codepoints to the color emoji font

### DIFF
--- a/home-manager/shell/kitty/default.nix
+++ b/home-manager/shell/kitty/default.nix
@@ -9,9 +9,17 @@ in
   programs.kitty.font.name = "HackGen Console NF";
   programs.kitty.font.size = 13;
 
-  # HackGen Console NF has no emoji glyphs; route emoji/pictograph/flag
-  # ranges to the platform's color emoji font instead of a tofu glyph.
-  programs.kitty.settings.symbol_map = "U+1F300-U+1FAFF,U+2600-U+27BF,U+1F1E6-U+1F1FF ${emojiFont}";
+  # HackGen Console NF has no emoji glyphs; route emoji ranges to the
+  # platform's color emoji font instead of a tofu glyph. Claude Code's own
+  # record-bullet (U+23FA) and other glyphs like U+2B50 star fell outside
+  # the original three ranges. The added codepoints list only the
+  # emoji-flagged characters in the Miscellaneous Technical (U+2300-U+23FF)
+  # and Miscellaneous Symbols and Arrows (U+2B00-U+2BFF) blocks, not the
+  # full blocks: routing the full blocks would also widen non-emoji glyphs
+  # they contain (e.g. U+2318 command key, U+23CE return) to the emoji
+  # font's wide aspect ratio, breaking column alignment wherever those
+  # appear.
+  programs.kitty.settings.symbol_map = "U+1F300-U+1FAFF,U+2600-U+27BF,U+1F1E6-U+1F1FF,U+231A-U+231B,U+2328,U+23CF,U+23E9-U+23F3,U+23F8-U+23FA,U+2B05-U+2B07,U+2B1B-U+2B1C,U+2B50,U+2B55 ${emojiFont}";
 
   programs.kitty.settings = {
     remember_window_size = false;


### PR DESCRIPTION
## Summary
- `symbol_map` in `home-manager/shell/kitty/default.nix` only covered three Unicode blocks, so glyphs in Miscellaneous Technical (U+2300-U+23FF) and Miscellaneous Symbols and Arrows (U+2B00-U+2BFF) fell back to `HackGen Console NF`, which has no emoji glyphs, and rendered as tofu. Reported symptom: Claude Code's own record-bullet glyph (U+23FA).
- Only the emoji-flagged codepoints of those two blocks are added (`U+231A-U+231B,U+2328,U+23CF,U+23E9-U+23F3,U+23F8-U+23FA` and `U+2B05-U+2B07,U+2B1B-U+2B1C,U+2B50,U+2B55`), not the full blocks, so non-emoji glyphs they also contain (command/option/control keys, return) keep rendering narrow on the primary font instead of flipping to the emoji font's wide aspect ratio.

## Test plan
- [x] `nix-instantiate --parse home-manager/shell/kitty/default.nix` — exit 0
- [x] `nix build --no-link '.#darwinConfigurations.M4-Max.config.home-manager.users.take.xdg.configFile."kitty/kitty.conf".source'` then grepped the rendered `symbol_map` line — byte-exact match to the expected value, `Apple Color Emoji` target confirmed
- [x] `nix eval --raw '.#nixosConfigurations.X13Gen2.config.home-manager.users.take.programs.kitty.settings.symbol_map'` — confirmed same ranges route to `Noto Color Emoji` on Linux
- [x] `nix flake check` from repo root — exit 0, no errors
- [x] Independently re-derived the emoji-flagged codepoint subset via `python3Packages.emoji`'s `EMOJI_DATA` (twice, by two different review passes) — matches the ranges in the diff
- [ ] Manual: open kitty, run `printf '⭐ ⌚ ⏰ ⏺ ⬛ ⬜\n'`, confirm no tofu boxes — not run in this environment (no GUI); recommended before/after applying to the live M4-Max system