### PR TITLE
fix(emacs): declare org-roam-buffer-open-buffer-list before consult-org-roam-buffer uses it

### DIFF
--- a/home-manager/editor/emacs/elisp/init.org
+++ b/home-manager/editor/emacs/elisp/init.org
@@ -6830,6 +6830,12 @@ https://github.com/ch11ng/exwm/wiki#gpg-pinentry
     (setq consult-org-roam-grep-func #'consult-ripgrep)
     (setq consult-org-roam-buffer-narrow-key ?r)
     (setq consult-org-roam-buffer-after-buffers nil))
+
+  ;; consult-org-roam-buffer.el reads/sets org-roam-buffer-open-buffer-list
+  ;; without ever declaring it, so exiting the minibuffer before its :items
+  ;; function has run signals (void-variable org-roam-buffer-open-buffer-list).
+  (with-eval-after-load 'consult-org-roam-buffer
+    (defvar org-roam-buffer-open-buffer-list nil))
 #+end_src
 *** org-roam-ui
 :PROPERTIES:


### PR DESCRIPTION
## Summary
- Adds a one-line `defvar` in `init.org` so `org-roam-buffer-open-buffer-list` is declared before `consult-org-roam-buffer` (loaded via `require` from `consult-org-roam.el`) can read it, fixing `(void-variable org-roam-buffer-open-buffer-list)` raised from `consult--preview-exit` on `minibuffer-exit-hook`.
- Root-caused to upstream `jgru/consult-org-roam`: `consult-org-roam-buffer.el` reads/sets this symbol without ever declaring it via `defvar`/`defcustom`; `org-roam` itself is not involved. No existing upstream issue tracks it.
- Kept as a local shim in this repo rather than filed upstream, by explicit request — this repo will keep re-adding the same `defvar` across future `consult-org-roam` version bumps unless someone later confirms upstream added its own declaration.

## Test plan
- [x] Reproduced the bug and confirmed the fix end-to-end against the actual pinned `consult-org-roam` package (`/nix/store/.../emacs-consult-org-roam-20260209.1805/`) in `emacs --batch`: calling the source's `:annotate`/`:with-title` path raises the void-variable error without the fix and doesn't with it.
- [x] Confirmed `defvar` fired from inside an already-executing `with-eval-after-load` callback (triggered via `require`, not `provide`) still declares the symbol special and initializes it — verified in `emacs --batch`, not by reasoning alone.
- [x] Confirmed no load-order/clobber hazard: no top-level `setq` of the symbol anywhere in the package, and no earlier reference to `consult-org-roam-buffer` in `init.org` (only autoloaded, deferred).
- [x] Isolated-snippet `check-parens` and `batch-byte-compile` on just the new form: clean.
- [x] Real Nix tangle of the working-tree `init.org` (`nix eval '.#darwinConfigurations.M4-Max.config.home-manager.users.take.home.file.".emacs.d/init.el".text' --raw`): exit 0, new lines land correctly, diff against baseline tangle shows only the intended 6 lines changed.
- [ ] Not run: full `nix build .#darwinConfigurations.M4-Max.system`, and an interactive Emacs session with a real org-roam database driving an actually keyboard-aborted `consult-buffer` session (the functional check calls the same source functions directly instead).