### PR TITLE
feat(emacs): break the line on C-j when nskk has nothing left to confirm

### DIFF
--- a/home-manager/editor/emacs/elisp/init.org
+++ b/home-manager/editor/emacs/elisp/init.org
@@ -1749,6 +1749,22 @@ Handles focus reporting (DECSET 1004) and bracketed paste (DECSET 2004)."
     (set-face-attribute 'nskk-cursor-jisx0208-latin nil :background "#ffb86c")
     (set-face-attribute 'nskk-cursor-abbrev nil :background "#bd93f9")
 
+    (defun my/nskk-kakutei-newline-on-hiragana-idle (&rest _)
+      "`nskk-kakutei' documents `hiragana-idle' as a no-op; this turns that
+no-op into a newline, so C-j breaks the line whenever nothing is left to
+confirm, at any point position. The ▽/▼ commit paths keep DDSKK's
+C-j-confirms-without-newline behavior. A later `:override' advice on
+`nskk-kakutei' added elsewhere in this file would silently stop this from
+firing (nadvice `:override' ignores anything already wrapped) — call this
+function explicitly from such an override rather than assuming it still
+runs."
+      (when (eq (nskk-current-kakutei-state) 'hiragana-idle)
+        (condition-case nil
+            (newline)
+          ((buffer-read-only text-read-only) nil))))
+
+    (advice-add 'nskk-kakutei :after #'my/nskk-kakutei-newline-on-hiragana-idle)
+
     (when-darwin
      (setopt nskk-server-enable t)
      (setopt nskk-server-host "localhost")


### PR DESCRIPTION
## What

nskk's C-j (`nskk-kakutei`) treats `hiragana-idle` as a documented no-op, so pressing it with no pending romaji and no active conversion did nothing. This makes it insert a newline in exactly that state, at any point position (end of line, mid-line, or on an empty line).

## Why this shape

`:after` advice rather than rebinding `"C-j"` in `nskk-mode-map`: `nskk-kakutei` has a single call site upstream (the keymap binding itself, `src/nskk.el:144`), so advice cannot misfire from another code path, and this file already customizes third-party commands this way (`lsp-rename`, `tab-new`, `org-table-align`) with no per-mode keymap-rebinding precedent to follow. nskk exposes no kakutei-time hook to use instead.

Conversion (▼) and preedit (▽) commit paths are deliberately untouched, keeping DDSKK's distinction that C-j confirms without a newline while RET confirms and breaks the line. Katakana and direct-input idle states are unchanged.

The `newline` call is wrapped in `condition-case` for `buffer-read-only` and `text-read-only`: nskk-mode can be active in a read-only buffer, and guarding on the `buffer-read-only` variable alone still threw on per-character `read-only` text properties, the shape `nskk-tutorial.el` and comint prompts use.

## Verification

No CI gate here covers Elisp — `nix flake check` runs treefmt and the `shared-ai-tools-lib` checks only. So this was checked by hand:

- `nix flake check` → exit 0
- `check-parens` on the tangled block in isolation → OK (full-buffer `check-parens` on this file has a pre-existing unrelated failure)
- Loaded the built `emacs-nskk-0.5.0` package in batch Emacs and drove `nskk-kakutei`: newline inserted at end-of-line, mid-line, and on an empty line in hiragana; no newline in katakana; no error in a read-only buffer

Not covered: confirmation in an interactive session, and undo granularity — batch mode does not reproduce the real command loop's undo-boundary insertion, so a single `undo` removing exactly the inserted newline is unverified.
