### PR TITLE
fix(emacs): don't newline when C-j commits a conversion in nskk

### DIFF
--- a/home-manager/editor/emacs/elisp/init.org
+++ b/home-manager/editor/emacs/elisp/init.org
@@ -1749,21 +1749,24 @@ Handles focus reporting (DECSET 1004) and bracketed paste (DECSET 2004)."
     (set-face-attribute 'nskk-cursor-jisx0208-latin nil :background "#ffb86c")
     (set-face-attribute 'nskk-cursor-abbrev nil :background "#bd93f9")
 
-    (defun my/nskk-kakutei-newline-on-hiragana-idle (&rest _)
-      "`nskk-kakutei' documents `hiragana-idle' as a no-op; this turns that
-no-op into a newline, so C-j breaks the line whenever nothing is left to
-confirm, at any point position. The ▽/▼ commit paths keep DDSKK's
-C-j-confirms-without-newline behavior. A later `:override' advice on
-`nskk-kakutei' added elsewhere in this file would silently stop this from
-firing (nadvice `:override' ignores anything already wrapped) — call this
-function explicitly from such an override rather than assuming it still
-runs."
-      (when (eq (nskk-current-kakutei-state) 'hiragana-idle)
-        (condition-case nil
-            (newline)
-          ((buffer-read-only text-read-only) nil))))
+    (defun my/nskk-kakutei-newline-on-hiragana-idle (orig-fn &rest args)
+      "`nskk-kakutei' documents `hiragana-idle' as a no-op; turn that no-op
+into a newline, so C-j breaks the line whenever nothing is left to confirm.
+The state must be read before ORIG-FN runs: committing ▽/▼ leaves nskk in
+`hiragana-idle', so an `:after' advice reading it afterwards cannot tell a
+commit apart from an idle keypress and appends a newline to every
+conversion. A later `:override' advice on `nskk-kakutei' added elsewhere in
+this file would silently stop this from firing (nadvice `:override' ignores
+anything already wrapped) — call this function explicitly from such an
+override rather than assuming it still runs."
+      (let ((idle (eq (nskk-current-kakutei-state) 'hiragana-idle)))
+        (prog1 (apply orig-fn args)
+          (when idle
+            (condition-case nil
+                (newline)
+              ((buffer-read-only text-read-only) nil))))))
 
-    (advice-add 'nskk-kakutei :after #'my/nskk-kakutei-newline-on-hiragana-idle)
+    (advice-add 'nskk-kakutei :around #'my/nskk-kakutei-newline-on-hiragana-idle)
 
     (when-darwin
      (setopt nskk-server-enable t)


### PR DESCRIPTION
## Bug

95bbaa01 (#111) read nskk's state with `:after` advice, which runs once `nskk-kakutei` has already finished. Committing ▽ or ▼ leaves nskk in `hiragana-idle`, so the check could not tell a commit apart from an idle keypress and appended a newline to every conversion:

- `▼かんじ` + C-j → `漢字\n` (should be `漢字`)
- `▽かんじ` + C-j → `かんじ\n` (should be `かんじ`)

## Fix

Read the state before the commit runs, via `:around`. The order is the only thing that distinguishes "a commit just happened" from "there was nothing to commit".

## Verification

Against the built `emacs-nskk-0.5.0` package in batch Emacs, driving real romaji input through to conversion:

| state | C-j result |
|---|---|
| ▼ conversion | `漢字` — no newline |
| ▽ preedit | `かんじ` — no newline |
| hiragana idle, end of line | newline |
| hiragana idle, mid-line | newline at point |
| hiragana idle, empty line | newline |
| katakana | no newline |
| pending romaji | discarded, no newline |
| latin | switches to hiragana, no newline |

The pre-fix code was run through the same steps first and does append the newline in the ▼ and ▽ cases, so these are regression checks rather than assertions of current behavior.

`nix flake check` exits 0; `check-parens` on the tangled block passes.

Note for anyone extending that check: `execute-kbd-macro` does not route through `nskk-mode-map` in batch Emacs (keys self-insert and the mode falls back to `direct-idle`), so a driver has to call the command `key-binding` reports, with `last-command-event` bound.

Still unverified: interactive confirmation in a real session, and undo granularity.
