### PR TITLE
feat(git-maintenance): git-bulk-clean v0.6.0 with credential helpers, drop built-in maintenance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -438,16 +438,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1783184238,
-        "narHash": "sha256-fONQE4zeV2dJg8s95lqWsZgTdY2/3qbyhBmHbYIFdhc=",
+        "lastModified": 1789120477,
+        "narHash": "sha256-lP3thFnW8vCH1fmNutuinVcU/QEmaYV1n5EI7rShfkY=",
         "owner": "takeokunn",
         "repo": "git-bulk-clean",
-        "rev": "84f81bee6fdfb827cf5305406127b54e9d41f87d",
+        "rev": "f5cafe42a4dfc87e786e9e822c686f8318c48f15",
         "type": "github"
       },
       "original": {
         "owner": "takeokunn",
-        "ref": "v0.3.0",
+        "ref": "v0.6.0",
         "repo": "git-bulk-clean",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
     nur-packages.inputs.nixpkgs.follows = "nixpkgs";
     darwin-vz-nix.url = "github:takeokunn/darwin-vz-nix";
     darwin-vz-nix.inputs.nixpkgs.follows = "nixpkgs";
-    git-bulk-clean.url = "github:takeokunn/git-bulk-clean/v0.3.0";
+    git-bulk-clean.url = "github:takeokunn/git-bulk-clean/v0.6.0";
     git-bulk-clean.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/home-manager/vcs/git/default.nix
+++ b/home-manager/vcs/git/default.nix
@@ -8,7 +8,6 @@
 
   programs.git.enable = true;
   programs.git.lfs.enable = true;
-  programs.git.maintenance.enable = true;
 
   programs.git.ignores = [
     "*.swp"
@@ -47,7 +46,6 @@
   programs.git.signing.signByDefault = true;
 
   programs.git.includes = [
-    { path = "~/.config/git/config.d/maintenance.conf"; }
     { path = "~/.config/git/work.gitconfig"; }
   ];
 

--- a/hosts/M4-Max/default.nix
+++ b/hosts/M4-Max/default.nix
@@ -69,18 +69,28 @@ nix-darwin.lib.darwinSystem {
         # inputs.zen-browser.homeModules.twilight  # TODO: hash mismatch, re-enable after fix
         inputs.agent-skills.homeManagerModules.default
         inputs.git-bulk-clean.homeManagerModules.default
-        {
-          services.git-maintenance = {
-            enable = true;
-            ghq.enable = true;
-            interval = 3600; # 1 hour
-          };
+        (
+          { pkgs, lib, ... }:
+          {
+            services.git-maintenance = {
+              enable = true;
+              ghq.enable = true;
+              interval = 3600; # 1 hour
+              # Private HTTPS remotes can only fetch through the gh credential
+              # helpers; the daemon resets every helper unless told otherwise.
+              credentialHelpers = true;
+            };
 
-          # launchd agents don't inherit home.sessionVariables (shell-only), so
-          # SSH-remote repos fail fetch without the agent socket set explicitly.
-          launchd.agents.git-maintenance.config.EnvironmentVariables.SSH_AUTH_SOCK =
-            "/Users/${username}/.gnupg/S.gpg-agent.ssh";
-        }
+            # launchd agents don't inherit home.sessionVariables (shell-only), so
+            # SSH-remote repos fail fetch without the agent socket set explicitly,
+            # and the credential helper scripts under ~/.config/git call `gh` by
+            # name, which launchd's default PATH cannot resolve.
+            launchd.agents.git-maintenance.config.EnvironmentVariables = {
+              SSH_AUTH_SOCK = "/Users/${username}/.gnupg/S.gpg-agent.ssh";
+              PATH = "${lib.makeBinPath [ pkgs.gh ]}:/usr/bin:/bin:/usr/sbin:/sbin";
+            };
+          }
+        )
       ];
       home-manager.extraSpecialArgs = {
         inherit inputs system username;


### PR DESCRIPTION
## Why

The hourly git-maintenance agent failed on nine private HTTPS repos every cycle. Root cause is in the tool, not the environment: git-bulk-clean resets `credential.helper` on every git call. v0.6.0 (released today: takeokunn/git-bulk-clean#14, #15) adds an opt-in that lets fetch and lfs prune use the configured helpers; this bumps to it and turns the option on, and puts gh on the agent's PATH because the second-account helper script invokes gh by name and launchd's default PATH has no Nix paths.

The built-in `programs.git.maintenance` is removed rather than repaired: its list lived in a hand-maintained maintenance.conf whose paths predate the bare-clone ghq layout, so its three agents exited 1 every run with no log, and the vendored service already covers every ghq repo.

## Judgment calls

- X13Gen2 shares the git module and now has no git maintenance at all. Wiring the vendored service there is a separate decision (its SSH_AUTH_SOCK override is launchd-only).
- Tag pruning does not change on this host with the bump: `fetch.pruneTags = true` is set globally here and the daemon does not override it. The bump stands on v0.4.0's `git branch -d` argument-injection fix and v0.5.0's environment hardening.
- The stray `~/.config/git/config.d/maintenance.conf` is a plain file, not Home Manager managed; it stays on disk and is a manual delete.

## Checked by hand, beyond CI

- `nix build .#darwinConfigurations.M4-Max.system` exit 0; the closure contains git-bulk-clean 0.6.0 and no `git-maintenance-{hourly,daily,weekly}` plist; the produced activation script carries Home Manager's launchd removal logic.
- One full cycle with the built binary and the exact agent `EnvironmentVariables`, in `env -i` with only that PATH, HOME and SSH_AUTH_SOCK, over every ghq repo: `97/97 ok, 0 failed`.
- `nix eval` of the agent set, the agent env, `programs.git.includes`, and X13Gen2's user timers show the intended values.
