### PR TITLE
feat(git-maintenance): run the vendored maintenance on X13Gen2, share its config

### DIFF
--- a/home-manager/vcs/advanced.nix
+++ b/home-manager/vcs/advanced.nix
@@ -3,5 +3,6 @@
     ./git
     ./gh
     ./gh-dash
+    ./git-maintenance
   ];
 }

--- a/home-manager/vcs/git-maintenance/default.nix
+++ b/home-manager/vcs/git-maintenance/default.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+  # Neither launchd agents nor systemd user units see shell session
+  # variables, and the credential helper scripts under ~/.config/git call
+  # `gh` by name, so each platform's unit gets an explicit PATH.
+  ghBin = lib.makeBinPath [ pkgs.gh ];
+in
+{
+  services.git-maintenance = {
+    enable = true;
+    ghq.enable = true;
+    interval = 3600; # 1 hour
+    # Private HTTPS remotes can only fetch through the gh credential
+    # helpers; the daemon resets every helper unless told otherwise.
+    credentialHelpers = true;
+  };
+
+  launchd.agents.git-maintenance.config.EnvironmentVariables = lib.mkIf isDarwin {
+    # SSH-remote repos fail fetch without the agent socket set explicitly.
+    SSH_AUTH_SOCK = "${config.home.homeDirectory}/.gnupg/S.gpg-agent.ssh";
+    PATH = "${ghBin}:/usr/bin:/bin:/usr/sbin:/sbin";
+  };
+
+  systemd.user.services.git-maintenance = lib.mkIf (!isDarwin) {
+    # Home Manager's ssh-auth-sock module (enabled by gpg-agent's SSH support)
+    # publishes SSH_AUTH_SOCK to the user manager from this oneshot; a daemon
+    # started earlier fetches agentless.
+    Unit.After = [ "set-SSH_AUTH_SOCK.service" ];
+    Service.Environment = [
+      "PATH=${ghBin}:/run/wrappers/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin"
+    ];
+  };
+}

--- a/hosts/M4-Max/default.nix
+++ b/hosts/M4-Max/default.nix
@@ -69,28 +69,6 @@ nix-darwin.lib.darwinSystem {
         # inputs.zen-browser.homeModules.twilight  # TODO: hash mismatch, re-enable after fix
         inputs.agent-skills.homeManagerModules.default
         inputs.git-bulk-clean.homeManagerModules.default
-        (
-          { pkgs, lib, ... }:
-          {
-            services.git-maintenance = {
-              enable = true;
-              ghq.enable = true;
-              interval = 3600; # 1 hour
-              # Private HTTPS remotes can only fetch through the gh credential
-              # helpers; the daemon resets every helper unless told otherwise.
-              credentialHelpers = true;
-            };
-
-            # launchd agents don't inherit home.sessionVariables (shell-only), so
-            # SSH-remote repos fail fetch without the agent socket set explicitly,
-            # and the credential helper scripts under ~/.config/git call `gh` by
-            # name, which launchd's default PATH cannot resolve.
-            launchd.agents.git-maintenance.config.EnvironmentVariables = {
-              SSH_AUTH_SOCK = "/Users/${username}/.gnupg/S.gpg-agent.ssh";
-              PATH = "${lib.makeBinPath [ pkgs.gh ]}:/usr/bin:/bin:/usr/sbin:/sbin";
-            };
-          }
-        )
       ];
       home-manager.extraSpecialArgs = {
         inherit inputs system username;

--- a/hosts/X13Gen2/default.nix
+++ b/hosts/X13Gen2/default.nix
@@ -44,6 +44,7 @@ nixpkgs.lib.nixosSystem {
         nixvim.homeModules.nixvim
         inputs.zen-browser.homeModules.twilight
         inputs.agent-skills.homeManagerModules.default
+        inputs.git-bulk-clean.homeManagerModules.default
       ];
       home-manager.extraSpecialArgs = {
         inherit inputs system;


### PR DESCRIPTION
## Why

X13Gen2 has had no git maintenance since #113 removed the built-in registration; the vendored service ran only on M4-Max, inline in its host file. This moves the configuration into one shared fragment (`home-manager/vcs/git-maintenance`), branching on platform, and registers the module on X13Gen2. Each host keeps its own registration line, matching how agent-skills and nixvim are wired.

## Judgment calls

- Linux gets `After=set-SSH_AUTH_SOCK.service` instead of a hardcoded socket path: Home Manager's ssh-auth-sock oneshot (enabled by gpg-agent's SSH support) publishes the live path into the user manager, so ordering is the correct dependency and survives a future gpg homedir change.
- The Linux unit gets an explicit PATH with gh first, then `/run/wrappers/bin`, the per-user profile, and the system profile; NixOS gives user units no PATH of its own and the credential helper scripts call gh by name.
- Same trust boundary as M4-Max, now on a second repo corpus: with `credentialHelpers` on, each ghq clone's own git config picks the helper that runs during fetch and lfs prune.

## Checked by hand, beyond CI

- M4-Max: `system.build.toplevel.drvPath` is byte-identical to base 01b86d32 (pure code motion), and the launchd agent JSON is identical.
- X13Gen2: the evaluated unit carries all `MAINTENANCE_*` entries plus PATH, `After=[network.target, set-SSH_AUTH_SOCK.service]`, `WantedBy=default.target`, and upstream's hardening (NoNewPrivileges, ProtectSystem=full, Nice=19, IOSchedulingClass=idle) intact. Base had no such service.
- OPPO-A79 evaluates unchanged; it never imports `vcs/advanced.nix`.
- Not possible from this host: building the X13Gen2 closure (no Linux builder configured). First `nixos-rebuild switch` there should be followed by `systemctl --user status git-maintenance` and a look at its journal for the first cycle.
