### PR TITLE
chore(git-maintenance): bump git-bulk-clean to v0.6.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,16 +412,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1789120477,
-        "narHash": "sha256-lP3thFnW8vCH1fmNutuinVcU/QEmaYV1n5EI7rShfkY=",
+        "lastModified": 1789153584,
+        "narHash": "sha256-XMoytpVt8HRcH5SGL6xVcCo33x7pZli9inplngAOhcU=",
         "owner": "takeokunn",
         "repo": "git-bulk-clean",
-        "rev": "f5cafe42a4dfc87e786e9e822c686f8318c48f15",
+        "rev": "85e342d02e7ecf2ebc670c9fab86217e7cdf99b5",
         "type": "github"
       },
       "original": {
         "owner": "takeokunn",
-        "ref": "v0.6.0",
+        "ref": "v0.6.1",
         "repo": "git-bulk-clean",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
     nur-packages.inputs.nixpkgs.follows = "nixpkgs";
     darwin-vz-nix.url = "github:takeokunn/darwin-vz-nix";
     darwin-vz-nix.inputs.nixpkgs.follows = "nixpkgs";
-    git-bulk-clean.url = "github:takeokunn/git-bulk-clean/v0.6.0";
+    git-bulk-clean.url = "github:takeokunn/git-bulk-clean/v0.6.1";
     git-bulk-clean.inputs.nixpkgs.follows = "nixpkgs";
   };
 


### PR DESCRIPTION
## Why

git-bulk-clean 0.6.1 (takeokunn/git-bulk-clean#16, released today) strips askpass, `GIT_PROXY_COMMAND`, and the `GIT_TRACE*` family from child git processes, and forwards SIGTERM/SIGINT to its process group so a fetch no longer outlives the agent when launchd restarts it.

## Checked by hand, beyond CI

- `nix build .#darwinConfigurations.M4-Max.system` exit 0; the agent's ProgramArguments and X13Gen2's ExecStart both resolve to 0.6.1 store paths; all 13 `MAINTENANCE_*` entries unchanged.
- One full cycle with the built binary and the exact agent environment over every ghq repo: 96/97 ok. The one failure was a transient `MERGE_RR.lock` in a repository an interactive session was working in at that moment (no lock present afterward, live daemon idle at the time).
