### PR TITLE
feat(opencode): unify oh-my-opencode lanes onto deepseek-v4.1-flash

### DIFF
--- a/home-manager/ai-tools/opencode/oh-my-opencode/agents.nix
+++ b/home-manager/ai-tools/opencode/oh-my-opencode/agents.nix
@@ -6,8 +6,8 @@ in
 # builtins.readFile, not documentation.
 {
   zeus = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append =
       models.promptLang
       + "\n\n"
@@ -15,52 +15,52 @@ in
     description = "Orchestrates high-stakes multi-system tasks and delegates independent work.";
   };
   themis = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Analyzes vulnerabilities, threat models, and security-sensitive code.";
   };
   daedalus = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Architecture designer. Cross-system, long-horizon design decisions with written rationale. Use oracle for fast advisory; use daedalus for final-say architectural choices.";
   };
   heracles = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Complex debugger. Multi-system root cause analysis spanning services, hard-to-reproduce failures. Use oracle for single-system debug; use heracles for cross-system investigations.";
   };
 
   sisyphus = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/sisyphus.md;
     description = "Plans tasks, delegates work, and consolidates results.";
   };
   atlas = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/atlas.md;
     description = "Execution conductor. Splits work into todos, delegates, and consolidates results.";
   };
   librarian = mkLane {
-    modelTier = models.deepseekFlash;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/librarian.md;
     description = "Specification researcher. Looks up docs via context7, web search, and API references.";
   };
   explore = mkLane {
-    modelTier = models.deepseekFlash;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/explore.md;
     description = "Fast explorer. Quick codebase navigation, file search, and pattern matching.";
   };
 
   hephaestus = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/hephaestus.md;
     description = "Implements complex multi-file changes and explores the codebase.";
     extra = {
@@ -68,32 +68,32 @@ in
     };
   };
   oracle = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/oracle.md;
     description = "Read-only advisor. Architecture design, code review, and deep debugging analysis.";
   };
   momus = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/momus.md;
     description = "Reviews code and design for defects, compatibility risks, and missed requirements.";
   };
   metis = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/metis.md;
     description = "Gap detector. Finds overlooked issues, ambiguities, and edge cases.";
   };
   "multimodal-looker" = mkLane {
-    modelTier = models.kimiVision;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/multimodal-looker.md;
     description = "Multimodal analyst. Interprets images, screenshots, diagrams, and visual content.";
   };
   prometheus = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/prometheus.md;
     description = "Planning specialist. Creates detailed implementation plans and task breakdowns.";
   };

--- a/home-manager/ai-tools/opencode/oh-my-opencode/categories.nix
+++ b/home-manager/ai-tools/opencode/oh-my-opencode/categories.nix
@@ -6,84 +6,84 @@ in
 # builtins.readFile, not documentation.
 {
   ultra = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Lane for multi-system tasks that need additional planning and review.";
   };
   security = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Security-focused analysis, vulnerability review, and threat modeling.";
   };
   architecture = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Cross-system or long-horizon architectural decisions requiring written rationale. Use ultrabrain for single-system tradeoffs; use architecture for irreversible structural choices.";
   };
 
   research = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/research.md;
     description = "Spec lookup, OSS pattern survey, and implementation research.";
   };
   writing = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/writing.md;
     description = "Documentation, ADRs, changelogs, and technical writing.";
   };
 
   ultrabrain = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/ultrabrain.md;
     description = "Reasoning about architecture, tradeoffs, and bug forensics.";
   };
   deep = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/deep.md;
     description = "Autonomous deep implementation, non-trivial debugging, and complex multi-file changes.";
   };
   "unspecified-high" = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/unspecified-high.md;
     description = "Default lane for complex general work.";
   };
   "visual-engineering" = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/visual-engineering.md;
     description = "Frontend UI implementation, styling, and component refactors.";
   };
   refactor = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/refactor.md;
     description = "Routine refactors, cleanup, repetitive edits, and test generation.";
   };
 
   quick = mkLane {
-    modelTier = models.deepseekFlash;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/quick.md;
     description = "Tiny mechanical edits: typos, trivial renames, one-file micro-fixes.";
   };
   "unspecified-low" = mkLane {
-    modelTier = models.deepseekFlash;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang + "\n\n" + builtins.readFile ./prompts/unspecified-low.md;
     description = "Default lane for routine and trivial implementation tasks.";
   };
 
   artistry = mkLane {
-    modelTier = models.deepseekPro;
-    variant = "xhigh";
+    modelTier = models.deepseek;
+    variant = "max";
     prompt_append = models.promptLang;
     description = "Uses unconventional approaches when standard patterns do not fit.";
   };

--- a/home-manager/ai-tools/opencode/oh-my-opencode/default.nix
+++ b/home-manager/ai-tools/opencode/oh-my-opencode/default.nix
@@ -16,6 +16,7 @@ pkgs.writeText "oh-my-opencode.json" (
     autoupdate = false;
     model_fallback = true;
     disabled_hooks = [ "comment-checker" ];
+    codegraph.enabled = false;
 
     inherit agents categories;
   }

--- a/home-manager/ai-tools/opencode/oh-my-opencode/models.nix
+++ b/home-manager/ai-tools/opencode/oh-my-opencode/models.nix
@@ -1,36 +1,19 @@
 let
   promptLang = "Think and work in English. Reply to the user and write documentation in Japanese.";
-  deepseekProModel = "opencode-go/deepseek-v4-pro";
-  deepseekFlashModel = "opencode-go/deepseek-v4-flash";
-  kimiVisionModel = "opencode-go/kimi-k2.6";
+  deepseekModel = "opencode-go/deepseek-v4.1-flash";
 in
 {
   inherit promptLang;
 
-  # DeepSeek-V4-Pro, the default tier for most agents/categories: orchestration, planning, review,
-  # and deep implementation. Fallback is the Go-only Flash tier, so it stays within the same
-  # (text-only) capability class.
-  deepseekPro = {
-    model = deepseekProModel;
+  # DeepSeek-V4.1-Flash, the single tier for every agent and category, including multimodal-looker.
+  # The prior V4 generation was text-only, requiring a separate Kimi vision tier; V4.1 Flash is
+  # claimed to handle image input directly (per efoo-team/opencode-setting's opencode-go_deepseek
+  # formation), but that capability is unverified from this repo. Fallback is self-referential
+  # since there is only one tier.
+  deepseek = {
+    model = deepseekModel;
     fallback = [
-      deepseekFlashModel
+      deepseekModel
     ];
-  };
-
-  # DeepSeek-V4-Flash, the fast, low-cost tier for routine work (quick/unspecified-low) and
-  # lighter-weight lookups (librarian/explore).
-  deepseekFlash = {
-    model = deepseekFlashModel;
-    fallback = [
-      deepseekProModel
-    ];
-  };
-
-  # Kimi-K2.6, vision-capable, for agents that must interpret images (DeepSeek V4 is text-only).
-  # No fallback: DeepSeek can't substitute for a vision task, so an outage should fail loudly
-  # rather than silently return text-only analysis of an image it never saw.
-  kimiVision = {
-    model = kimiVisionModel;
-    fallback = [ ];
   };
 }


### PR DESCRIPTION
## Summary
- Collapse the `deepseekPro`/`deepseekFlash`/`kimiVision` model tiers in `home-manager/ai-tools/opencode/oh-my-opencode/models.nix` into one `deepseek` tier (`opencode-go/deepseek-v4.1-flash`, self-referential fallback), matching efoo-team/opencode-setting's `formations/opencode-go_deepseek.jsonc`.
- Point all 27 agent/category lanes at that tier and set `variant = "max"` on every one.
- Add `codegraph.enabled = false` to the generated `oh-my-opencode.json`.

## Scope notes
- `opencode-config.nix`'s own `model`/`small_model` fields are intentionally left on the prior generation (`opencode-go/deepseek-v4-pro`/`deepseek-v4-flash`) — a separate file/schema, out of scope for this change. Whether to align it is still open.
- No automated regression check exists yet for this JSON's content (model/variant/fallback/codegraph values); a `checks.oh-my-opencode-config` sketch was proposed but not wired into `flake.nix` pending a separate decision.

## Test plan
- [x] `nix build --no-link --print-out-paths '.#darwinConfigurations.M4-Max.config.home-manager.users.take.xdg.configFile."opencode/oh-my-opencode.json".source'` — exit 0; parsed output confirms all 27 lanes use `model=opencode-go/deepseek-v4.1-flash`, `variant=max`, `fallback_models=[opencode-go/deepseek-v4.1-flash]`, and `codegraph.enabled=false`.
- [x] `nix build --no-link '.#darwinConfigurations.M4-Max.system'` — exit 0 (full toplevel eval, not the vacuous `nix flake check` darwin output).
- [x] `nix build --no-link '.#checks.aarch64-darwin.treefmt'` — exit 0, 0 files changed.
- [x] `nix build --no-link '.#checks.aarch64-darwin.shared-ai-tools-lib'` — exit 0 (unrelated shared-lib suite unaffected).
- [ ] `nix build '.#nixosConfigurations.X13Gen2.config.system.build.toplevel'` — not run (this machine has no `x86_64-linux` build capability); verified instead by diffing the target derivation's `.drv` environment against the M4-Max output (byte-identical, 27/27 lanes). A Linux-capable runner should still confirm with a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)