### PR TITLE
feat(homebrew): add arto cask

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -11,6 +11,7 @@
   homebrew.casks = [
     "amical"
     "aquaskk"
+    "arto-app/tap/arto"
     "cleanshot"
     "claude"
     "clickup"


### PR DESCRIPTION
## Why

Arto (a local, offline Markdown reader) ships only through its own tap, `arto-app/tap`, not the default `homebrew/cask` tap — `brew info --cask arto` returns "No Cask with this name exists" against the default tap. The entry uses the fully-qualified `arto-app/tap/arto` string rather than adding a separate `homebrew.taps` entry (this repo has never needed one); nix-darwin's homebrew module and Homebrew itself both auto-tap from a qualified cask name.

## Verification beyond CI

CI's `nix-flake` job runs on `ubuntu-latest` and evaluates `darwinConfigurations` but does not build the M4-Max toplevel (this repo's own `darwinConfigurations` check is eval-only, not build-only, in `nix flake check`). Locally:
- `nix build .#darwinConfigurations.M4-Max.system --no-link` — exit 0.
- `nix eval .#darwinConfigurations.M4-Max.config.homebrew.casks --json` — resolved list contains `cask "arto-app/tap/arto", trusted: true`.
- Traced Homebrew's own source (`bundle/{dsl,cask,subcommand/cleanup}.rb`) to confirm this file's existing `onActivation.cleanup = "uninstall"` + `--force-cleanup` won't treat the tap-qualified entry as undeclared and uninstall it on the next activation: Homebrew sanitizes the declared name to its bare token for the cleanup comparison on both sides.

## Out of scope

Arto ships unsigned/unnotarized; its README requires a manual `xattr -dr com.apple.quarantine /Applications/Arto.app` after install. Left as a manual one-time step rather than a new `system.activationScripts` entry, to keep this change at one line.

## Note for reviewer

Unlike this file's other cask entries, `arto-app/tap` is a third-party tap with no Homebrew-core review boundary. Flagging for awareness; not a blocker since it's the app's only distribution channel.